### PR TITLE
Update scheduled task function names and documentation for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Get-Help Start-PSMouseJiggler -Full
 - `Show-PSMouseJigglerGUI` - Launch the graphical user interface
 - `Get-PSMouseJigglerConfig` - Get current configuration settings
 - `Set-PSMouseJigglerConfig` - Set configuration options
-- `New-PSMouseJigglerScheduledTask` - Create a scheduled task for automatic jiggling
 
 For detailed usage instructions, please refer to the [USAGE.md](docs/USAGE.md) file.
 

--- a/Validate.ps1
+++ b/Validate.ps1
@@ -13,7 +13,8 @@ Write-Host "1. Testing module manifest..." -ForegroundColor Yellow
 try {
     $manifest = Test-ModuleManifest -Path "src\PSMouseJiggler\PSMouseJiggler.psd1" -ErrorAction Stop
     $successes += "✓ Module manifest is valid (Version: $($manifest.Version))"
-} catch {
+}
+catch {
     $errors += "✗ Module manifest validation failed: $($_.Exception.Message)"
 }
 
@@ -24,7 +25,8 @@ try {
     $fullPath = Join-Path $PSScriptRoot "src\PSMouseJiggler\PSMouseJiggler.psd1"
     Import-Module $fullPath -Force -ErrorAction Stop
     $successes += "✓ Module imported successfully"
-} catch {
+}
+catch {
     $errors += "✗ Module import failed: $($_.Exception.Message)"
 }
 
@@ -41,7 +43,8 @@ foreach ($func in $expectedFunctions) {
     try {
         Get-Command $func -ErrorAction Stop | Out-Null
         $successes += "✓ Function '$func' is available"
-    } catch {
+    }
+    catch {
         $errors += "✗ Function '$func' not found"
     }
 }
@@ -52,10 +55,12 @@ try {
     $config = Get-Configuration -ErrorAction Stop
     if ($config) {
         $successes += "✓ Configuration system works"
-    } else {
+    }
+    else {
         $errors += "✗ Configuration system returned null"
     }
-} catch {
+}
+catch {
     $errors += "✗ Configuration system failed: $($_.Exception.Message)"
 }
 
@@ -65,10 +70,12 @@ try {
     $testResult = Invoke-Pester -Path "tests\PSMouseJiggler.Module.Tests.ps1" -PassThru -ErrorAction Stop
     if ($testResult.FailedCount -eq 0) {
         $successes += "✓ All $($testResult.PassedCount) Pester tests passed"
-    } else {
+    }
+    else {
         $errors += "✗ $($testResult.FailedCount) Pester tests failed"
     }
-} catch {
+}
+catch {
     $errors += "✗ Pester tests failed to run: $($_.Exception.Message)"
 }
 
@@ -79,13 +86,15 @@ $releaseContent = Get-Content ".github\workflows\release.yml" -Raw
 
 if ($ciContent -match "src/PSMouseJiggler/PSMouseJiggler\.psd1") {
     $successes += "✓ CI workflow uses correct path"
-} else {
+}
+else {
     $errors += "✗ CI workflow path is incorrect"
 }
 
 if ($releaseContent -match "src\\PSMouseJiggler\\") {
     $successes += "✓ Release workflow uses correct path"
-} else {
+}
+else {
     $errors += "✗ Release workflow path is incorrect"
 }
 
@@ -102,7 +111,8 @@ if ($errors.Count -gt 0) {
     $errors | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
     Write-Host "`nValidation FAILED" -ForegroundColor Red
     exit 1
-} else {
+}
+else {
     Write-Host "`nValidation PASSED - All components working correctly!" -ForegroundColor Green
     Write-Host "The PSMouseJiggler module is ready for use and deployment." -ForegroundColor Green
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -90,13 +90,13 @@ Create scheduled tasks for automatic jiggling:
 
 ```powershell
 # Create a new scheduled task
-New-ScheduledTask -TaskName "MorningJiggler" -Action "powershell.exe -Command 'Start-PSMouseJiggler -Duration 3600'" -StartTime (Get-Date "09:00")
+New-PSMJScheduledTask -TaskName "MorningJiggler" -Action "powershell.exe -Command 'Start-PSMouseJiggler -Duration 3600'" -StartTime (Get-Date "09:00")
 
 # List existing tasks
-Get-ScheduledTasks
+Get-PSMJScheduledTasks
 
 # Remove a task
-Remove-ScheduledTask -TaskName "MorningJiggler"
+Remove-PSMJScheduledTask -TaskName "MorningJiggler"
 ```
 
 ## Advanced Keep-Awake Methods

--- a/src/PSMouseJiggler/PSMouseJiggler.psd1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psd1
@@ -77,11 +77,11 @@
         'Move-Mouse',
         'Start-MovementPattern',
         'Stop-MovementPattern',
-        'Get-ScheduledTasks',
-        'New-ScheduledTask',
-        'Remove-ScheduledTask',
-        'Start-ScheduledTask',
-        'Stop-ScheduledTask',
+        'Get-PSMJScheduledTasks',       # Updated name
+        'New-PSMJScheduledTask',        # Updated name
+        'Remove-PSMJScheduledTask',     # Updated name
+        'Start-PSMJScheduledTask',      # Updated name
+        'Stop-PSMJScheduledTask',       # Updated name
         'Prevent-SystemIdle',
         'Send-KeyboardInput',
         'Send-MouseInput',

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -715,10 +715,10 @@ function Stop-MovementPattern {
     Name or pattern to search for in task names.
 
 .EXAMPLE
-    Get-ScheduledTasks -TaskName "PSMouseJiggler"
+    Get-PSMJScheduledTasks -TaskName "PSMouseJiggler"
     Gets all tasks with "PSMouseJiggler" in the name.
 #>
-function Get-ScheduledTasks {
+function Get-PSMJScheduledTasks {
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -755,10 +755,10 @@ function Get-ScheduledTasks {
     How often to repeat the task in minutes.
 
 .EXAMPLE
-    New-ScheduledTask -TaskName "MyJiggler" -Action "powershell.exe -Command 'Start-PSMouseJiggler'" -StartTime (Get-Date).AddMinutes(5)
+    New-PSMJScheduledTask -TaskName "MyJiggler" -Action "powershell.exe -Command 'Start-PSMouseJiggler'" -StartTime (Get-Date).AddMinutes(5)
     Creates a task to start jiggling in 5 minutes.
 #>
-function New-ScheduledTask {
+function New-PSMJScheduledTask {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -806,10 +806,10 @@ function New-ScheduledTask {
     Name of the task to remove.
 
 .EXAMPLE
-    Remove-ScheduledTask -TaskName "MyJiggler"
+    Remove-PSMJScheduledTask -TaskName "MyJiggler"
     Removes the MyJiggler scheduled task.
 #>
-function Remove-ScheduledTask {
+function Remove-PSMJScheduledTask {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -836,10 +836,10 @@ function Remove-ScheduledTask {
     Name of the task to start.
 
 .EXAMPLE
-    Start-ScheduledTask -TaskName "MyJiggler"
+    Start-PSMJScheduledTask -TaskName "MyJiggler"
     Starts the MyJiggler scheduled task.
 #>
-function Start-ScheduledTask {
+function Start-PSMJScheduledTask {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -866,10 +866,10 @@ function Start-ScheduledTask {
     Name of the task to stop.
 
 .EXAMPLE
-    Stop-ScheduledTask -TaskName "MyJiggler"
+    Stop-PSMJScheduledTask -TaskName "MyJiggler"
     Stops the MyJiggler scheduled task.
 #>
-function Stop-ScheduledTask {
+function Stop-PSMJScheduledTask {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -1242,11 +1242,11 @@ Export-ModuleMember -Function @(
     'Move-Mouse',
     'Start-MovementPattern',
     'Stop-MovementPattern',
-    'Get-ScheduledTasks',
-    'New-ScheduledTask',
-    'Remove-ScheduledTask',
-    'Start-ScheduledTask',
-    'Stop-ScheduledTask',
+    'Get-PSMJScheduledTasks',        # Updated name
+    'New-PSMJScheduledTask',         # Updated name
+    'Remove-PSMJScheduledTask',      # Updated name
+    'Start-PSMJScheduledTask',       # Updated name
+    'Stop-PSMJScheduledTask',        # Updated name
     # New functions
     'Prevent-SystemIdle',
     'Send-KeyboardInput',

--- a/src/PSMouseJiggler/README.md
+++ b/src/PSMouseJiggler/README.md
@@ -65,11 +65,11 @@ Show-PSMouseJigglerGUI
 - `Stop-MovementPattern` - Stop movement pattern
 
 ### Scheduled Task Functions
-- `Get-ScheduledTasks` - Get PSMouseJiggler scheduled tasks
-- `New-ScheduledTask` - Create new scheduled task
-- `Remove-ScheduledTask` - Remove scheduled task
-- `Start-ScheduledTask` - Start scheduled task
-- `Stop-ScheduledTask` - Stop scheduled task
+- `Get-PSMJScheduledTasks` - Get PSMouseJiggler scheduled tasks
+- `New-PSMJScheduledTask` - Create new scheduled task
+- `Remove-PSMJScheduledTask` - Remove scheduled task
+- `Start-PSMJScheduledTask` - Start scheduled task
+- `Stop-PSMJScheduledTask` - Stop scheduled task
 
 ## Examples
 
@@ -103,7 +103,7 @@ Reset-Configuration
 ### Scheduled Tasks
 ```powershell
 # Create a scheduled task to start jiggling at 9 AM daily
-New-ScheduledTask -TaskName "MorningJiggler" -Action "powershell.exe -Command 'Start-PSMouseJiggler -Duration 3600'" -StartTime (Get-Date "09:00")
+New-PSMJScheduledTask -TaskName "MorningJiggler" -Action "powershell.exe -Command 'Start-PSMouseJiggler -Duration 3600'" -StartTime (Get-Date "09:00")
 ```
 
 ## Requirements

--- a/tests/PSMouseJiggler.Tests.ps1
+++ b/tests/PSMouseJiggler.Tests.ps1
@@ -30,7 +30,24 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
             $requiredFunctions = @(
                 'Start-PSMouseJiggler',
                 'Stop-PSMouseJiggler',
+                'Get-NewMousePosition',
                 'Show-PSMouseJigglerGUI',
+                'Get-Configuration',
+                'Save-Configuration',
+                'Update-Configuration',
+                'Reset-Configuration',
+                'Get-RandomMovementPattern',
+                'Move-Mouse',
+                'Start-MovementPattern',
+                'Stop-MovementPattern',
+                'Get-PSMJScheduledTasks',       # Updated name
+                'New-PSMJScheduledTask',        # Updated name
+                'Remove-PSMJScheduledTask',     # Updated name
+                'Start-PSMJScheduledTask',      # Updated name
+                'Stop-PSMJScheduledTask',       # Updated name
+                'Prevent-SystemIdle',
+                'Send-KeyboardInput',
+                'Send-MouseInput',
                 'Start-KeepAwake'
             )
 


### PR DESCRIPTION
updated some names while clashed with already popular functions and more alarming called themselves from within the function, obvs I haven't tested and not the first time Copilot has done that to me.
        'Get-ScheduledTasks',       # Updated name
        'New-ScheduledTask',        # Updated name
        'Remove-ScheduledTask',     # Updated name
        'Start-ScheduledTask',      # Updated name
        'Stop-ScheduledTask',       # Updated name

        'Get-PSMJScheduledTasks',       # Updated name
        'New-PSMJScheduledTask',        # Updated name
        'Remove-PSMJScheduledTask',     # Updated name
        'Start-PSMJScheduledTask',      # Updated name
        'Stop-PSMJScheduledTask',       # Updated name
       