### PR TITLE
v2.0.0: Unify Start-KeepAwake into Start-PSMouseJiggler, add AppKeepAlive strategy, fix cursor jiggling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "chat.tools.terminal.autoApprove": {
-        "Invoke-Pester": true
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "chat.tools.terminal.autoApprove": {
+        "Invoke-Pester": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Stop-PSMouseJiggler
 - `Start-PSMouseJiggler` - Start basic mouse jiggling with pattern-based movement
 - `Stop-PSMouseJiggler` - Stop the currently running mouse jiggler or keep-awake
 - `Start-KeepAwake` - Advanced multi-method keep-awake functionality
+- `Get-PSMJRecommendedMethods` - Show methods selected by an intelligent strategy
 - `Show-PSMouseJigglerGUI` - Launch the graphical user interface
 
 #### Configuration Functions
@@ -97,9 +98,42 @@ Stop-PSMouseJiggler
 - `Save-Configuration` - Save configuration to file
 - `Update-Configuration` - Update specific configuration values
 - `Reset-Configuration` - Reset to default configuration
+- `Get-PSMJProfile` - List saved profiles or retrieve one by name
+- `Save-PSMJProfile` - Save or replace a named profile
+- `Remove-PSMJProfile` - Remove a saved profile
+- `Start-PSMJProfile` - Start a saved mouse-jiggler or keep-awake profile
+- `Get-PSMJDiagnostics` - Report runtime, configuration, and profile health
+
+Example saved profile:
+
+```powershell
+$profile = [PSCustomObject]@{
+   Mode            = 'MouseJiggler'
+   Interval        = 1500
+   Duration        = 3600
+   MovementPattern = 'Circular'
+   Incognito       = $true
+}
+
+Save-PSMJProfile -Name 'Presentation' -Profile $profile
+Get-PSMJProfile -Name 'Presentation'
+Start-PSMJProfile -Name 'Presentation'
+Get-PSMJDiagnostics | Format-List
+Remove-PSMJProfile -Name 'Presentation'
+```
+
+Keep-awake strategies are opt-in. Existing calls use `Manual` behavior. Use `Adaptive` to select a low-disruption method combination for the current Windows environment, `LowImpact` to use the Windows power API only, or `Compatibility` to use standard software mouse movement:
+
+```powershell
+Get-PSMJRecommendedMethods -Strategy Adaptive
+Start-KeepAwake -Strategy Adaptive -Interval 30000
+Start-KeepAwake -Strategy LowImpact -Duration 3600
+```
 
 #### Scheduled Task Functions (with PSMJ prefix to avoid conflicts)
 - `Get-PSMJScheduledTasks` - List PSMouseJiggler scheduled tasks
+- `Get-PSMJScheduledTaskStatus` - Return normalized task status for monitoring or GUI use
+- `New-PSMJScheduledProfileTask` - Schedule a saved profile by name
 - `New-PSMJScheduledTask` - Create a new scheduled task
 - `Remove-PSMJScheduledTask` - Remove a scheduled task
 - `Start-PSMJScheduledTask` - Manually start a scheduled task

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Start-PSMouseJiggler -Interval 2000 -MovementPattern Circular -Duration 3600
 Start-PSMouseJiggler -Incognito
 
 # Advanced keep-awake with multiple methods
-Start-KeepAwake -Methods @('MouseHardware', 'Keyboard', 'SystemAPI') -Interval 30000
+Start-PSMouseJiggler -Methods @('MouseHardware', 'Keyboard', 'SystemAPI') -Interval 30000
+
+# Keep some apps active without moving the mouse (SystemAPI + Keyboard)
+Start-PSMouseJiggler -Strategy AppKeepAlive -Interval 30000
 
 # Stop jiggling
 Stop-PSMouseJiggler
@@ -87,9 +90,8 @@ Stop-PSMouseJiggler
 ### Available Commands
 
 #### Core Functions
-- `Start-PSMouseJiggler` - Start basic mouse jiggling with pattern-based movement
-- `Stop-PSMouseJiggler` - Stop the currently running mouse jiggler or keep-awake
-- `Start-KeepAwake` - Advanced multi-method keep-awake functionality
+- `Start-PSMouseJiggler` - Start mouse jiggling and/or multi-method keep-awake (Methods/Strategy params)
+- `Stop-PSMouseJiggler` - Stop the currently running jiggler
 - `Get-PSMJRecommendedMethods` - Show methods selected by an intelligent strategy
 - `Show-PSMouseJigglerGUI` - Launch the graphical user interface
 
@@ -101,14 +103,13 @@ Stop-PSMouseJiggler
 - `Get-PSMJProfile` - List saved profiles or retrieve one by name
 - `Save-PSMJProfile` - Save or replace a named profile
 - `Remove-PSMJProfile` - Remove a saved profile
-- `Start-PSMJProfile` - Start a saved mouse-jiggler or keep-awake profile
+- `Start-PSMJProfile` - Start a saved profile
 - `Get-PSMJDiagnostics` - Report runtime, configuration, and profile health
 
 Example saved profile:
 
 ```powershell
 $profile = [PSCustomObject]@{
-   Mode            = 'MouseJiggler'
    Interval        = 1500
    Duration        = 3600
    MovementPattern = 'Circular'
@@ -122,12 +123,13 @@ Get-PSMJDiagnostics | Format-List
 Remove-PSMJProfile -Name 'Presentation'
 ```
 
-Keep-awake strategies are opt-in. Existing calls use `Manual` behavior. Use `Adaptive` to select a low-disruption method combination for the current Windows environment, `LowImpact` to use the Windows power API only, or `Compatibility` to use standard software mouse movement:
+Keep-awake strategies are opt-in. The default `Manual` strategy uses whatever `-Methods` you pass in (or plain mouse jiggling if omitted). Use `Adaptive` to select a low-disruption method combination for the current Windows environment, `LowImpact` to use the Windows power API only, `Compatibility` to use standard software mouse movement, or `AppKeepAlive` to combine System API + Keyboard (keeps some Windows apps active without moving the mouse):
 
 ```powershell
 Get-PSMJRecommendedMethods -Strategy Adaptive
-Start-KeepAwake -Strategy Adaptive -Interval 30000
-Start-KeepAwake -Strategy LowImpact -Duration 3600
+Start-PSMouseJiggler -Strategy Adaptive -Interval 30000
+Start-PSMouseJiggler -Strategy LowImpact -Duration 3600
+Start-PSMouseJiggler -Strategy AppKeepAlive -Duration 3600
 ```
 
 #### Scheduled Task Functions (with PSMJ prefix to avoid conflicts)

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,65 @@
+# PSMouseJiggler Test Plan (pre-merge / pre-release)
+
+Use this checklist before merging to `main` and publishing a new version to the PowerShell Gallery.
+Run through it any time `Start-PSMouseJiggler`, profiles, the GUI, or scheduled tasks change.
+
+## 1. Automated tests
+
+- [ ] `Invoke-Pester tests/PSMouseJiggler.Tests.ps1 -Output Detailed` — all tests pass
+- [ ] `./Validate.ps1` — clean run, no missing functions or manifest errors
+- [ ] `Test-ModuleManifest src/PSMouseJiggler/PSMouseJiggler.psd1` — succeeds, version matches intended release
+
+## 2. Manual: core jiggling
+
+- [ ] `Start-PSMouseJiggler` (defaults) moves the mouse, `Stop-PSMouseJiggler` stops it
+- [ ] `-MovementPattern` Random / Horizontal / Vertical / Circular all move the cursor as expected
+- [ ] `-Interval` and `-Duration` are respected (job stops itself after Duration)
+- [ ] Calling `Start-PSMouseJiggler` while already running shows the "already running" warning (or clears host silently with `-Incognito`)
+
+## 3. Manual: Methods / Strategy (former Start-KeepAwake behavior)
+
+- [ ] `-Methods @('MouseHardware')`
+- [ ] `-Methods @('MouseSoftware','MouseHardware')`
+- [ ] `-Methods @('Keyboard')` — no visible mouse movement
+- [ ] `-Methods @('SystemAPI')` — no visible mouse movement, system stays awake
+- [ ] `-Methods @('All')` — all four methods cycle
+- [ ] `-Strategy Adaptive` / `LowImpact` / `Compatibility`
+- [ ] `-Strategy AppKeepAlive` — confirm SystemAPI + Keyboard keeps a target app (e.g. a chat/media app) marked active without moving the mouse
+
+## 4. Manual: Incognito mode
+
+- [ ] Console: `-Incognito` clears the console on start
+- [ ] GUI: Incognito checkbox minimizes the window and hides it from the taskbar; restoring on Stop works
+
+## 5. Manual: GUI (`Show-PSMouseJigglerGUI`)
+
+- [ ] Basic tab: all 4 patterns, all 3 mouse input methods (Software/Hardware/Both), Start/Stop toggle status correctly
+- [ ] Advanced tab: each checkbox combination starts correctly; rejects starting with zero methods selected
+- [ ] Quick Launch: all 5 profile buttons start correctly and switch to Basic tab with correct status text
+- [ ] Help dialog opens and displays current text
+- [ ] Reopening the GUI after a console-started session reflects "Running (Started from Console)"
+
+## 6. Manual: Profiles
+
+- [ ] `Save-PSMJProfile` / `Get-PSMJProfile` / `Remove-PSMJProfile` round-trip
+- [ ] Save and start a profile with only Interval/Duration/MovementPattern (no Methods/Strategy)
+- [ ] Save and start a profile with `Methods`
+- [ ] Save and start a profile with `Strategy = 'AppKeepAlive'`
+- [ ] Confirm profiles saved by an older module version (with a `Mode` field) load without error (the field is ignored)
+
+## 7. Manual: Scheduled tasks
+
+- [ ] `New-PSMJScheduledTask` / `Start-PSMJScheduledTask` / `Stop-PSMJScheduledTask` / `Remove-PSMJScheduledTask`
+- [ ] `New-PSMJScheduledProfileTask` against a saved profile, then manually trigger and confirm it starts jiggling
+
+## 8. Manual: Diagnostics
+
+- [ ] `Get-PSMJDiagnostics` reports `IsRunning`/`JobState` correctly while running and after stopping
+- [ ] `ProfileCount` reflects saved profiles
+
+## Sign-off
+
+- [ ] All automated tests green
+- [ ] All manual checks above completed on a Windows machine
+- [ ] `PSMouseJiggler.psd1` `ModuleVersion` and `ReleaseNotes` updated
+- [ ] Reviewer approval obtained before merging to `main` / publishing to PowerShell Gallery

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -370,7 +370,7 @@ Start-PSMouseJiggler -Methods @('SystemAPI') -Interval 60000
 # Create task for weekday work hours (9 AM - 5 PM)
 New-PSMJScheduledTask `
     -TaskName "WorkHoursJiggler" `
-    -Action "powershell.exe -Command 'Start-PSMouseJiggler -Methods @(''MouseSoftware'', ''SystemAPI'') -Duration 28800 -Incognito'" `
+    -Action "Import-Module PSMouseJiggler; Start-PSMouseJiggler -Methods @('MouseSoftware', 'SystemAPI') -Duration 28800 -Incognito" `
     -StartTime (Get-Date "09:00")
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -297,13 +297,13 @@ PSMouseJiggler uses PSMJ-prefixed function names to avoid conflicts with other P
 # Create task to start jiggling at 9 AM daily
 New-PSMJScheduledTask `
     -TaskName "MorningJiggler" `
-    -Action "powershell.exe -Command 'Start-PSMouseJiggler -Duration 28800'" `
+    -Action "Import-Module PSMouseJiggler; Start-PSMouseJiggler -Duration 28800" `
     -StartTime (Get-Date "09:00")
 
 # Create repeating task (every 4 hours)
 New-PSMJScheduledTask `
     -TaskName "PeriodicJiggler" `
-    -Action "powershell.exe -Command 'Start-PSMouseJiggler -Duration 3600'" `
+    -Action "Import-Module PSMouseJiggler; Start-PSMouseJiggler -Duration 3600" `
     -StartTime (Get-Date).AddMinutes(5) `
     -RepeatIntervalMinutes 240
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -404,6 +404,24 @@ Get-Help Start-PSMouseJiggler -Examples
 Get-Help Start-PSMouseJiggler -Parameter MovementPattern
 ```
 
+### Scheduled Task Status
+
+Use the normalized status command to inspect task state without parsing raw Task Scheduler objects:
+
+```powershell
+Get-PSMJScheduledTaskStatus | Format-Table TaskName, State, Enabled, NextRunTime, LastTaskResult
+```
+
+To schedule a saved profile, create the profile first and then reference it by name:
+
+```powershell
+New-PSMJScheduledProfileTask `
+   -TaskName 'PSMJ-WorkHours' `
+   -ProfileName 'Presentation' `
+   -StartTime (Get-Date).AddMinutes(5) `
+   -RepeatIntervalMinutes 30
+```
+
 ### GUI Help
 
 Click the "? Help" button in the GUI for comprehensive help information.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -146,19 +146,22 @@ Start-PSMouseJiggler -Interval 1500 -MovementPattern Horizontal -Duration 7200 -
 
 ```powershell
 # Use all methods
-Start-KeepAwake -Methods @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
+Start-PSMouseJiggler -Methods @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
 
 # Use specific methods
-Start-KeepAwake -Methods @('MouseHardware', 'SystemAPI') -Interval 30000
+Start-PSMouseJiggler -Methods @('MouseHardware', 'SystemAPI') -Interval 30000
 
 # Keyboard only with incognito mode
-Start-KeepAwake -Methods @('Keyboard') -Interval 30000 -Incognito
+Start-PSMouseJiggler -Methods @('Keyboard') -Interval 30000 -Incognito
 
 # System API only (minimal resource usage)
-Start-KeepAwake -Methods @('SystemAPI') -Interval 30000
+Start-PSMouseJiggler -Methods @('SystemAPI') -Interval 30000
 
 # Custom interval (15 seconds)
-Start-KeepAwake -Methods @('MouseSoftware', 'Keyboard') -Interval 15000 -Duration 3600
+Start-PSMouseJiggler -Methods @('MouseSoftware', 'Keyboard') -Interval 15000 -Duration 3600
+
+# AppKeepAlive strategy: SystemAPI + Keyboard, keeps some apps active without moving the mouse
+Start-PSMouseJiggler -Strategy AppKeepAlive -Interval 30000
 ```
 
 ### Stopping Jiggling
@@ -218,7 +221,7 @@ Run discreetly without visible console output:
 ```powershell
 # Command line incognito
 Start-PSMouseJiggler -Incognito
-Start-KeepAwake -Incognito
+Start-PSMouseJiggler -Methods @('SystemAPI') -Incognito
 
 # GUI incognito - check the checkbox before starting
 # - Minimizes window when started
@@ -339,7 +342,7 @@ Start-PSMouseJiggler -MovementPattern Random -Interval 1000 -Duration 7200 -Inco
 For systems with strict power policies:
 
 ```powershell
-Start-KeepAwake -Methods @('MouseHardware', 'SystemAPI') -Interval 30000 -Incognito
+Start-PSMouseJiggler -Methods @('MouseHardware', 'SystemAPI') -Interval 30000 -Incognito
 ```
 
 ### Example 3: Overnight Monitoring
@@ -358,7 +361,7 @@ Start-PSMouseJiggler -MovementPattern Circular -Interval 30000
 System API only for minimum CPU usage:
 
 ```powershell
-Start-KeepAwake -Methods @('SystemAPI') -Interval 60000
+Start-PSMouseJiggler -Methods @('SystemAPI') -Interval 60000
 ```
 
 ### Example 5: Scheduled Workday Jiggling
@@ -367,7 +370,7 @@ Start-KeepAwake -Methods @('SystemAPI') -Interval 60000
 # Create task for weekday work hours (9 AM - 5 PM)
 New-PSMJScheduledTask `
     -TaskName "WorkHoursJiggler" `
-    -Action "powershell.exe -Command 'Start-KeepAwake -Methods @(''MouseSoftware'', ''SystemAPI'') -Duration 28800 -Incognito'" `
+    -Action "powershell.exe -Command 'Start-PSMouseJiggler -Methods @(''MouseSoftware'', ''SystemAPI'') -Duration 28800 -Incognito'" `
     -StartTime (Get-Date "09:00")
 ```
 
@@ -379,11 +382,11 @@ Start-PSMouseJiggler -Interval 1000 -Duration 60
 Stop-PSMouseJiggler
 
 # Test hardware mouse only
-Start-KeepAwake -Methods @('MouseHardware') -Interval 1000 -Duration 60
+Start-PSMouseJiggler -Methods @('MouseHardware') -Interval 1000 -Duration 60
 Stop-PSMouseJiggler
 
 # Test keyboard only
-Start-KeepAwake -Methods @('Keyboard') -Interval 5000 -Duration 60
+Start-PSMouseJiggler -Methods @('Keyboard') -Interval 5000 -Duration 60
 Stop-PSMouseJiggler
 ```
 
@@ -394,7 +397,6 @@ Stop-PSMouseJiggler
 ```powershell
 # Get detailed help for any command
 Get-Help Start-PSMouseJiggler -Full
-Get-Help Start-KeepAwake -Full
 Get-Help Show-PSMouseJigglerGUI -Full
 
 # Get examples only

--- a/install.ps1
+++ b/install.ps1
@@ -13,9 +13,23 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
     $moduleBasePath = Join-Path $documentsPath "PowerShell\Modules"
 }
 
-$moduleInstallPath = Join-Path $moduleBasePath "PSMouseJiggler"
+$sourceManifestPath = Join-Path $PSScriptRoot "src\PSMouseJiggler\PSMouseJiggler.psd1"
+$moduleVersion = (Test-ModuleManifest -Path $sourceManifestPath).Version
+$moduleRootPath = Join-Path $moduleBasePath "PSMouseJiggler"
+$moduleInstallPath = Join-Path $moduleRootPath $moduleVersion
 
 Write-Host "Installing PSMouseJiggler module to: $moduleInstallPath" -ForegroundColor Yellow
+
+# Remove a legacy flat (unversioned) copy left by older versions of this script.
+# A flat manifest sitting next to versioned subfolders makes Import-Module ignore it and load a stale version instead.
+$legacyManifestPath = Join-Path $moduleRootPath "PSMouseJiggler.psd1"
+if (Test-Path -Path $legacyManifestPath) {
+    Write-Host "Removing legacy unversioned install at: $moduleRootPath" -ForegroundColor Yellow
+    Get-ChildItem -Path $moduleRootPath -File | Remove-Item -Force
+    Get-ChildItem -Path $moduleRootPath -Directory -Exclude $moduleVersion.ToString() -ErrorAction SilentlyContinue |
+    Where-Object { -not (Test-Path (Join-Path $_.FullName "PSMouseJiggler.psd1")) } |
+    Remove-Item -Recurse -Force
+}
 
 # Create module directory if it doesn't exist
 if (-Not (Test-Path -Path $moduleInstallPath)) {

--- a/src/PSMouseJiggler/PSMouseJiggler.psd1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psd1
@@ -7,7 +7,7 @@
     RootModule             = 'PSMouseJiggler.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.1.0'
+    ModuleVersion          = '2.0.0'
 
     # Supported PSEditions
     CompatiblePSEditions   = @('Desktop', 'Core')
@@ -92,8 +92,7 @@
         'Prevent-SystemIdle',
         'Send-KeyboardInput',
         'Send-MouseInput',
-        'Get-PSMJRecommendedMethods',
-        'Start-KeepAwake'
+        'Get-PSMJRecommendedMethods'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -131,6 +130,19 @@
 
             # ReleaseNotes of this module
             ReleaseNotes             = @'
+                Version 2.0.0 (BREAKING CHANGES)
+                - Removed Start-KeepAwake. Use Start-PSMouseJiggler -Methods / -Strategy instead:
+                    - Old: Start-KeepAwake -Methods @('MouseHardware','SystemAPI')
+                    - New: Start-PSMouseJiggler -Methods @('MouseHardware','SystemAPI')
+                - Added -Methods and -Strategy parameters directly to Start-PSMouseJiggler, unifying
+                  basic mouse jiggling and multi-method keep-awake into a single entry point
+                - Added new 'AppKeepAlive' strategy (SystemAPI + Keyboard) to keep some Windows apps
+                  active without visible mouse movement; available via -Strategy AppKeepAlive or
+                  Get-PSMJRecommendedMethods -Strategy AppKeepAlive
+                - Saved profiles no longer use a 'Mode' field (MouseJiggler/KeepAwake); profiles now
+                  simply carry Interval/Duration/MovementPattern/Methods/Strategy/Incognito and are
+                  started with Start-PSMouseJiggler
+
                 Version 1.1.0 (October 2025)
                 - Added modern tabbed GUI interface with three main tabs:
                     - Basic Mode: Simple mouse jiggling controls

--- a/src/PSMouseJiggler/PSMouseJiggler.psd1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psd1
@@ -73,11 +73,18 @@
         'Save-Configuration',
         'Update-Configuration',
         'Reset-Configuration',
+        'Get-PSMJProfile',
+        'Save-PSMJProfile',
+        'Remove-PSMJProfile',
+        'Start-PSMJProfile',
+        'Get-PSMJDiagnostics',
         'Get-RandomMovementPattern',
         'Move-Mouse',
         'Start-MovementPattern',
         'Stop-MovementPattern',
         'Get-PSMJScheduledTasks',       # Updated name
+        'Get-PSMJScheduledTaskStatus',
+        'New-PSMJScheduledProfileTask',
         'New-PSMJScheduledTask',        # Updated name
         'Remove-PSMJScheduledTask',     # Updated name
         'Start-PSMJScheduledTask',      # Updated name
@@ -85,6 +92,7 @@
         'Prevent-SystemIdle',
         'Send-KeyboardInput',
         'Send-MouseInput',
+        'Get-PSMJRecommendedMethods',
         'Start-KeepAwake'
     )
 

--- a/src/PSMouseJiggler/PSMouseJiggler.psd1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psd1
@@ -141,7 +141,7 @@
                   Get-PSMJRecommendedMethods -Strategy AppKeepAlive
                 - Saved profiles no longer use a 'Mode' field (MouseJiggler/KeepAwake); profiles now
                   simply carry Interval/Duration/MovementPattern/Methods/Strategy/Incognito and are
-                  started with Start-PSMouseJiggler
+                  started with Start-PSMJProfile
 
                 Version 1.1.0 (October 2025)
                 - Added modern tabbed GUI interface with three main tabs:

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -30,16 +30,24 @@ function Sync-PSMJState {
 
 <#
 .SYNOPSIS
-    Starts the PSMouseJiggler to simulate mouse movements.
+    Starts the PSMouseJiggler to simulate mouse movements and/or keep the system awake.
 
 .DESCRIPTION
-    Starts mouse jiggling with specified interval and movement pattern to prevent the system from going idle.
+    Starts mouse jiggling with a specified interval and movement pattern, or combines
+    multiple keep-awake methods (software/hardware mouse, keyboard, system API) to
+    prevent the system from going idle.
 
 .PARAMETER Interval
-    Time in milliseconds between mouse movements. Default is 1000ms.
+    Time in milliseconds between actions. Default is 1000ms.
 
 .PARAMETER MovementPattern
-    The pattern for mouse movement. Valid values: 'Random', 'Horizontal', 'Vertical', 'Circular'. Default is 'Random'.
+    The pattern for mouse movement when using the default 'MouseSoftware' method. Valid values: 'Random', 'Horizontal', 'Vertical', 'Circular'. Default is 'Random'.
+
+.PARAMETER Methods
+    Array of keep-awake methods to use: 'MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI', or 'All'. Default is 'MouseSoftware'.
+
+.PARAMETER Strategy
+    An optional recommended method combination that overrides -Methods: 'Manual' (default, uses -Methods as-is), 'Adaptive', 'LowImpact', 'Compatibility', 'AppKeepAlive'.
 
 .PARAMETER Duration
     Duration in seconds to run the jiggler. If not specified, runs indefinitely until stopped.
@@ -54,6 +62,14 @@ When enabled, clears the console after starting to maintain privacy/discretion.
 .EXAMPLE
     Start-PSMouseJiggler -Interval 2000 -MovementPattern 'Circular' -Duration 300
     Starts mouse jiggling every 2 seconds using circular pattern for 5 minutes.
+
+.EXAMPLE
+    Start-PSMouseJiggler -Methods @('MouseHardware', 'SystemAPI') -Interval 30000
+    Combines hardware mouse input and the system power API for strict security policies.
+
+.EXAMPLE
+    Start-PSMouseJiggler -Strategy AppKeepAlive
+    Uses the SystemAPI + Keyboard combo to keep some Windows apps active without moving the mouse.
 #>
 function Start-PSMouseJiggler {
     [CmdletBinding()]
@@ -65,6 +81,14 @@ function Start-PSMouseJiggler {
         [Parameter()]
         [ValidateSet('Random', 'Horizontal', 'Vertical', 'Circular')]
         [string]$MovementPattern = 'Random',
+
+        [Parameter()]
+        [ValidateSet('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI', 'All')]
+        [string[]]$Methods = @('MouseSoftware'),
+
+        [Parameter()]
+        [ValidateSet('Manual', 'Adaptive', 'LowImpact', 'Compatibility', 'AppKeepAlive')]
+        [string]$Strategy = 'Manual',
 
         [Parameter()]
         [ValidateRange(0, 2147483647)]
@@ -85,55 +109,204 @@ function Start-PSMouseJiggler {
         return
     }
 
-    Write-Host "Starting PSMouseJiggler with $MovementPattern pattern, interval: $Interval ms" -ForegroundColor Green
+    if ($Strategy -ne 'Manual') {
+        $Methods = Get-PSMJRecommendedMethods -Strategy $Strategy
+    }
+    elseif ($Methods -contains 'All') {
+        $Methods = @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
+    }
+
+    # Preserve the original single-mouse, pattern-based behavior when only the default method is requested
+    $useSinglePatternJob = ($Methods.Count -eq 1 -and $Methods[0] -eq 'MouseSoftware')
+
+    Write-Host "Starting PSMouseJiggler with methods: $($Methods -join ', '), interval: $Interval ms" -ForegroundColor Green
 
     $script:JigglingActive = $true
     $startTime = Get-Date
 
-    $script:JigglingJob = Start-Job -ScriptBlock {
-        param($Interval, $MovementPattern, $Duration, $StartTime)
+    if ($Methods -contains 'SystemAPI') {
+        Prevent-SystemIdle
+    }
 
-        Add-Type -AssemblyName System.Windows.Forms
-        Add-Type -AssemblyName System.Drawing
+    if ($useSinglePatternJob) {
+        $script:JigglingJob = Start-Job -ScriptBlock {
+            param($Interval, $MovementPattern, $Duration, $StartTime)
 
-        $endTime = if ($Duration -gt 0) { $StartTime.AddSeconds($Duration) } else { [DateTime]::MaxValue }
+            # Use raw Win32 cursor calls; System.Windows.Forms.Cursor is unreliable without a UI message pump in a background job
+            Add-Type -TypeDefinition @"
+            using System;
+            using System.Runtime.InteropServices;
 
-        while ((Get-Date) -lt $endTime) {
-            $currentPos = [System.Windows.Forms.Cursor]::Position
+            public static class CursorNative {
+                [StructLayout(LayoutKind.Sequential)]
+                public struct POINT {
+                    public int X;
+                    public int Y;
+                }
 
-            # Determine movement pattern
-            switch ($MovementPattern) {
-                'Random' {
-                    $xOffset = Get-Random -Minimum -10 -Maximum 11
-                    $yOffset = Get-Random -Minimum -10 -Maximum 11
+                [DllImport("user32.dll")]
+                public static extern bool GetCursorPos(out POINT lpPoint);
+
+                [DllImport("user32.dll")]
+                public static extern bool SetCursorPos(int X, int Y);
+            }
+"@
+
+            $endTime = if ($Duration -gt 0) { $StartTime.AddSeconds($Duration) } else { [DateTime]::MaxValue }
+
+            while ((Get-Date) -lt $endTime) {
+                $currentPos = New-Object CursorNative+POINT
+                [CursorNative]::GetCursorPos([ref]$currentPos) | Out-Null
+
+                # Determine movement pattern
+                switch ($MovementPattern) {
+                    'Random' {
+                        $xOffset = Get-Random -Minimum -10 -Maximum 11
+                        $yOffset = Get-Random -Minimum -10 -Maximum 11
+                    }
+                    'Horizontal' {
+                        $xOffset = if ((Get-Random -Minimum 0 -Maximum 2) -eq 0) { -5 } else { 5 }
+                        $yOffset = 0
+                    }
+                    'Vertical' {
+                        $xOffset = 0
+                        $yOffset = if ((Get-Random -Minimum 0 -Maximum 2) -eq 0) { -5 } else { 5 }
+                    }
+                    'Circular' {
+                        $angle = (Get-Date).Millisecond / 1000 * 2 * [Math]::PI
+                        $xOffset = [Math]::Round([Math]::Sin($angle) * 10)
+                        $yOffset = [Math]::Round([Math]::Cos($angle) * 10)
+                    }
+                    default {
+                        $xOffset = Get-Random -Minimum -5 -Maximum 6
+                        $yOffset = Get-Random -Minimum -5 -Maximum 6
+                    }
                 }
-                'Horizontal' {
-                    $xOffset = if ((Get-Random -Minimum 0 -Maximum 2) -eq 0) { -5 } else { 5 }
-                    $yOffset = 0
-                }
-                'Vertical' {
-                    $xOffset = 0
-                    $yOffset = if ((Get-Random -Minimum 0 -Maximum 2) -eq 0) { -5 } else { 5 }
-                }
-                'Circular' {
-                    $angle = (Get-Date).Millisecond / 1000 * 2 * [Math]::PI
-                    $xOffset = [Math]::Round([Math]::Sin($angle) * 10)
-                    $yOffset = [Math]::Round([Math]::Cos($angle) * 10)
-                }
-                default {
-                    $xOffset = Get-Random -Minimum -5 -Maximum 6
-                    $yOffset = Get-Random -Minimum -5 -Maximum 6
-                }
+
+                # Move the mouse
+                [CursorNative]::SetCursorPos($currentPos.X + $xOffset, $currentPos.Y + $yOffset) | Out-Null
+
+                # Wait for the specified interval
+                Start-Sleep -Milliseconds $Interval
+            }
+        } -ArgumentList $Interval, $MovementPattern, $Duration, $startTime
+    }
+    else {
+        $script:JigglingJob = Start-Job -ScriptBlock {
+            param($Interval, $Methods, $Duration, $StartTime)
+
+            # Import required assemblies
+            Add-Type -AssemblyName System.Windows.Forms
+            Add-Type -AssemblyName System.Drawing
+
+            # Define required P/Invoke structures and methods
+            Add-Type -TypeDefinition @"
+            using System;
+            using System.Runtime.InteropServices;
+
+            public static class DisplayState {
+                [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+                public static extern uint SetThreadExecutionState(uint esFlags);
+
+                public const uint ES_CONTINUOUS = 0x80000000;
+                public const uint ES_SYSTEM_REQUIRED = 0x00000001;
+                public const uint ES_DISPLAY_REQUIRED = 0x00000002;
             }
 
-            # Move the mouse
-            $newPos = New-Object System.Drawing.Point($currentPos.X + $xOffset, $currentPos.Y + $yOffset)
-            [System.Windows.Forms.Cursor]::Position = $newPos
+            public static class CursorNative {
+                [StructLayout(LayoutKind.Sequential)]
+                public struct POINT {
+                    public int X;
+                    public int Y;
+                }
 
-            # Wait for the specified interval
-            Start-Sleep -Milliseconds $Interval
-        }
-    } -ArgumentList $Interval, $MovementPattern, $Duration, $startTime
+                [DllImport("user32.dll")]
+                public static extern bool GetCursorPos(out POINT lpPoint);
+
+                [DllImport("user32.dll")]
+                public static extern bool SetCursorPos(int X, int Y);
+            }
+
+            public static class MouseSimulator {
+                [StructLayout(LayoutKind.Sequential)]
+                public struct MOUSEINPUT {
+                    public int dx;
+                    public int dy;
+                    public uint mouseData;
+                    public uint dwFlags;
+                    public uint time;
+                    public IntPtr dwExtraInfo;
+                }
+
+                [StructLayout(LayoutKind.Sequential)]
+                public struct INPUT {
+                    public uint type;
+                    public MOUSEINPUT mi;
+                }
+
+                [DllImport("user32.dll", SetLastError = true)]
+                public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+                public const int INPUT_MOUSE = 0;
+                public const int MOUSEEVENTF_MOVE = 0x0001;
+            }
+"@
+
+            $endTime = if ($Duration -gt 0) { $StartTime.AddSeconds($Duration) } else { [DateTime]::MaxValue }
+
+            while ((Get-Date) -lt $endTime) {
+                # Randomly select a method from the provided methods
+                $method = $Methods | Get-Random
+
+                switch ($method) {
+                    'MouseSoftware' {
+                        # Move mouse using software method; raw Win32 calls avoid Windows.Forms.Cursor's UI-thread requirement
+                        $currentPos = New-Object CursorNative+POINT
+                        [CursorNative]::GetCursorPos([ref]$currentPos) | Out-Null
+                        $xOffset = Get-Random -Minimum -10 -Maximum 11
+                        $yOffset = Get-Random -Minimum -10 -Maximum 11
+                        [CursorNative]::SetCursorPos($currentPos.X + $xOffset, $currentPos.Y + $yOffset) | Out-Null
+
+                        # Move back to original position after a short delay to minimize disruption
+                        Start-Sleep -Milliseconds 100
+                        [CursorNative]::SetCursorPos($currentPos.X, $currentPos.Y) | Out-Null
+                    }
+                    'MouseHardware' {
+                        # Use hardware-level mouse movement
+                        $mouseInputStructure = New-Object MouseSimulator+INPUT
+                        $mouseInputStructure.type = [MouseSimulator]::INPUT_MOUSE
+                        $mouseInputStructure.mi.dx = Get-Random -Minimum -5 -Maximum 6
+                        $mouseInputStructure.mi.dy = Get-Random -Minimum -5 -Maximum 6
+                        $mouseInputStructure.mi.dwFlags = [MouseSimulator]::MOUSEEVENTF_MOVE
+                        $mouseInputStructure.mi.time = 0
+                        $mouseInputStructure.mi.dwExtraInfo = [IntPtr]::Zero
+
+                        $inputArray = @($mouseInputStructure)
+                        [MouseSimulator]::SendInput(1, $inputArray, [System.Runtime.InteropServices.Marshal]::SizeOf([type][MouseSimulator+INPUT])) | Out-Null
+                    }
+                    'Keyboard' {
+                        # Press a non-disruptive key (F15 is rarely used)
+                        [System.Windows.Forms.SendKeys]::SendWait("{F15}")
+                    }
+                    'SystemAPI' {
+                        # Directly tell Windows to stay awake
+                        [DisplayState]::SetThreadExecutionState(
+                            [DisplayState]::ES_CONTINUOUS -bor
+                            [DisplayState]::ES_SYSTEM_REQUIRED -bor
+                            [DisplayState]::ES_DISPLAY_REQUIRED)
+                    }
+                }
+
+                # Wait for the specified interval
+                Start-Sleep -Milliseconds $Interval
+            }
+
+            # Reset execution state if we used the API
+            if ($Methods -contains 'SystemAPI') {
+                [DisplayState]::SetThreadExecutionState([DisplayState]::ES_CONTINUOUS)
+            }
+        } -ArgumentList $Interval, $Methods, $Duration, $startTime
+    }
 
     if ($Duration -gt 0) {
         Write-Host "PSMouseJiggler will run for $Duration seconds" -ForegroundColor Yellow
@@ -649,7 +822,7 @@ function Show-PSMouseJigglerGUI {
 
     $profile2Button.Add_Click({
             try {
-                Start-KeepAwake -Methods @('MouseHardware', 'SystemAPI') -Interval 30000 -Duration 0 -Incognito
+                Start-PSMouseJiggler -Methods @('MouseHardware', 'SystemAPI') -Interval 30000 -Duration 0 -Incognito
                 $statusLabel.Text = "Status: Running (Maximum Security)"
                 $statusLabel.ForeColor = [System.Drawing.Color]::DarkGreen
                 $statusDetailsLabel.Text = "Profile: Maximum Security | Hardware + System API, 30s interval"
@@ -679,7 +852,7 @@ function Show-PSMouseJigglerGUI {
 
     $profile3Button.Add_Click({
             try {
-                Start-KeepAwake -Methods @('Keyboard') -Interval 30000 -Duration 0 -Incognito
+                Start-PSMouseJiggler -Methods @('Keyboard') -Interval 30000 -Duration 0 -Incognito
                 $statusLabel.Text = "Status: Running (Keyboard Only)"
                 $statusLabel.ForeColor = [System.Drawing.Color]::DarkGreen
                 $statusDetailsLabel.Text = "Profile: Keyboard Only | F15 key press, 30s interval"
@@ -709,7 +882,7 @@ function Show-PSMouseJigglerGUI {
 
     $profile4Button.Add_Click({
             try {
-                Start-KeepAwake -Methods @('SystemAPI') -Interval 30000 -Duration 0 -Incognito
+                Start-PSMouseJiggler -Methods @('SystemAPI') -Interval 30000 -Duration 0 -Incognito
                 $statusLabel.Text = "Status: Running (System API Only)"
                 $statusLabel.ForeColor = [System.Drawing.Color]::DarkGreen
                 $statusDetailsLabel.Text = "Profile: System API | Direct power management control"
@@ -733,7 +906,7 @@ function Show-PSMouseJigglerGUI {
 
     $profile5Button.Add_Click({
             try {
-                Start-KeepAwake -Methods @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI') -Interval 30000 -Duration 0 -Incognito
+                Start-PSMouseJiggler -Methods @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI') -Interval 30000 -Duration 0 -Incognito
                 $statusLabel.Text = "Status: Running (All Methods)"
                 $statusLabel.ForeColor = [System.Drawing.Color]::DarkGreen
                 $statusDetailsLabel.Text = "Profile: All Methods | Maximum reliability with all techniques"
@@ -769,12 +942,12 @@ function Show-PSMouseJigglerGUI {
                     # Determine mouse methods based on selection
                     if ($mouseTypeComboBox.SelectedIndex -eq 1) {
                         # Hardware only
-                        Start-KeepAwake -Methods @('MouseHardware') -Interval $interval -Duration $duration -Incognito:$incognito
+                        Start-PSMouseJiggler -Methods @('MouseHardware') -Interval $interval -Duration $duration -Incognito:$incognito
                         $statusDetailsLabel.Text = "Mode: Basic | Pattern: $pattern | Method: Hardware Mouse"
                     }
                     elseif ($mouseTypeComboBox.SelectedIndex -eq 2) {
                         # Both methods
-                        Start-KeepAwake -Methods @('MouseSoftware', 'MouseHardware') -Interval $interval -Duration $duration -Incognito:$incognito
+                        Start-PSMouseJiggler -Methods @('MouseSoftware', 'MouseHardware') -Interval $interval -Duration $duration -Incognito:$incognito
                         $statusDetailsLabel.Text = "Mode: Basic | Pattern: $pattern | Method: Both (Software + Hardware)"
                     }
                     else {
@@ -803,7 +976,7 @@ function Show-PSMouseJigglerGUI {
                     $duration = [int]$advDurationTextBox.Text
                     $incognito = $advIncognitoCheckbox.Checked
 
-                    Start-KeepAwake -Methods $methods -Interval $interval -Duration $duration -Incognito:$incognito
+                    Start-PSMouseJiggler -Methods $methods -Interval $interval -Duration $duration -Incognito:$incognito
                     $statusLabel.Text = "Status: Running (Advanced)"
                     $statusLabel.ForeColor = [System.Drawing.Color]::DarkGreen
                     $statusDetailsLabel.Text = "Mode: Advanced | Methods: $($methods -join ', ')"
@@ -1157,9 +1330,13 @@ function Save-PSMJProfile {
         [string]$ConfigFilePath
     )
 
-    $mode = $Profile.PSObject.Properties['Mode']
-    if ($null -eq $mode -or $mode.Value -notin @('MouseJiggler', 'KeepAwake')) {
-        throw "Profile Mode must be MouseJiggler or KeepAwake."
+    $methods = $Profile.PSObject.Properties['Methods']
+    if ($null -ne $methods) {
+        foreach ($method in @($methods.Value)) {
+            if ($method -notin @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI', 'All')) {
+                throw "Profile Methods entries must be MouseSoftware, MouseHardware, Keyboard, SystemAPI, or All."
+            }
+        }
     }
 
     $interval = $Profile.PSObject.Properties['Interval']
@@ -1229,31 +1406,20 @@ function Start-PSMJProfile {
     $profile = Get-PSMJProfile -Name $Name -ConfigFilePath $ConfigFilePath -ErrorAction Stop
     $incognito = [bool]$profile.Incognito
 
-    switch ($profile.Mode) {
-        'MouseJiggler' {
-            $parameters = @{
-                Interval        = if ($null -ne $profile.Interval) { [int]$profile.Interval } else { 1000 }
-                MovementPattern = if ($profile.MovementPattern) { [string]$profile.MovementPattern } else { 'Random' }
-                Duration        = if ($null -ne $profile.Duration) { [int]$profile.Duration } else { 0 }
-                Incognito       = $incognito
-            }
-            Start-PSMouseJiggler @parameters
-        }
-        'KeepAwake' {
-            $methods = if ($null -ne $profile.Methods) { @($profile.Methods) } else { @('All') }
-            $parameters = @{
-                Methods   = $methods
-                Strategy  = if ($profile.Strategy) { [string]$profile.Strategy } else { 'Manual' }
-                Interval  = if ($null -ne $profile.Interval) { [int]$profile.Interval } else { 30000 }
-                Duration  = if ($null -ne $profile.Duration) { [int]$profile.Duration } else { 0 }
-                Incognito = $incognito
-            }
-            Start-KeepAwake @parameters
-        }
-        default {
-            throw "Profile '$Name' has unsupported mode '$($profile.Mode)'."
-        }
+    $parameters = @{
+        Interval        = if ($null -ne $profile.Interval) { [int]$profile.Interval } else { 1000 }
+        MovementPattern = if ($profile.MovementPattern) { [string]$profile.MovementPattern } else { 'Random' }
+        Duration        = if ($null -ne $profile.Duration) { [int]$profile.Duration } else { 0 }
+        Incognito       = $incognito
     }
+    if ($null -ne $profile.Methods) {
+        $parameters.Methods = @($profile.Methods)
+    }
+    if ($profile.Strategy) {
+        $parameters.Strategy = [string]$profile.Strategy
+    }
+
+    Start-PSMouseJiggler @parameters
 }
 
 function Get-PSMJDiagnostics {
@@ -1887,7 +2053,7 @@ function Get-PSMJRecommendedMethods {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [ValidateSet('Adaptive', 'LowImpact', 'Compatibility')]
+        [ValidateSet('Adaptive', 'LowImpact', 'Compatibility', 'AppKeepAlive')]
         [string]$Strategy = 'Adaptive'
     )
 
@@ -1899,201 +2065,15 @@ function Get-PSMJRecommendedMethods {
         return @('MouseSoftware')
     }
 
+    if ($Strategy -eq 'AppKeepAlive') {
+        return @('SystemAPI', 'Keyboard')
+    }
+
     if ($env:OS -eq 'Windows_NT') {
         return @('SystemAPI', 'MouseHardware')
     }
 
     return @('MouseSoftware')
-}
-
-<#
-.SYNOPSIS
-    Keeps the system awake using multiple methods.
-
-.DESCRIPTION
-    Combines various techniques to prevent system sleep, including
-    mouse movements, keyboard input, and Windows API calls.
-
-.PARAMETER Methods
-    Array of methods to use. Default includes all available methods.
-
-.PARAMETER Interval
-    Time in milliseconds between actions. Default is 30000 (30 seconds).
-
-.PARAMETER Duration
-    Duration in seconds to run. Default is 0 (indefinite).
-
-.PARAMETER Incognito
-When enabled, clears the console after starting to maintain privacy/discretion.
-
-.EXAMPLE
-    Start-KeepAwake -Interval 60000 -Duration 3600
-    Keeps the system awake for 1 hour, performing actions every 60 seconds.
-#>
-function Start-KeepAwake {
-    [CmdletBinding()]
-    param (
-        [Parameter()]
-        [ValidateSet('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI', 'All')]
-        [string[]]$Methods = @('All'),
-
-        [Parameter()]
-        [ValidateSet('Manual', 'Adaptive')]
-        [string]$Strategy = 'Manual',
-
-        [Parameter()]
-        [ValidateRange(1, 2147483647)]
-        [int]$Interval = 30000,
-
-        [Parameter()]
-        [ValidateRange(0, 2147483647)]
-        [int]$Duration = 0,
-
-        [Parameter()]
-        [switch]$Incognito
-    )
-
-    Sync-PSMJState
-    if ($script:JigglingActive) {
-        if ($Incognito) {
-            Clear-Host
-        }
-        else {
-            Write-Warning "PSMouseJiggler is already running. Use Stop-PSMouseJiggler to stop it first."
-        }
-        return
-    }
-
-    Write-Host "Starting PSMouseJiggler KeepAwake with multiple methods, interval: $Interval ms" -ForegroundColor Green
-
-    $script:JigglingActive = $true
-    $startTime = Get-Date
-
-    # If 'All' is specified, use all methods
-    if ($Strategy -eq 'Adaptive') {
-        $Methods = Get-PSMJRecommendedMethods -Strategy Adaptive
-    }
-    elseif ($Methods -contains 'All') {
-        $Methods = @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
-    }
-
-    # Start the prevention immediately using the API
-    if ($Methods -contains 'SystemAPI') {
-        Prevent-SystemIdle
-    }
-
-    $script:JigglingJob = Start-Job -ScriptBlock {
-        param($Interval, $Methods, $Duration, $StartTime)
-
-        # Import required assemblies
-        Add-Type -AssemblyName System.Windows.Forms
-        Add-Type -AssemblyName System.Drawing
-
-        # Define required P/Invoke structures and methods
-        Add-Type -TypeDefinition @"
-        using System;
-        using System.Runtime.InteropServices;
-
-        public static class DisplayState {
-            [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-            public static extern uint SetThreadExecutionState(uint esFlags);
-
-            public const uint ES_CONTINUOUS = 0x80000000;
-            public const uint ES_SYSTEM_REQUIRED = 0x00000001;
-            public const uint ES_DISPLAY_REQUIRED = 0x00000002;
-        }
-
-        public static class MouseSimulator {
-            [StructLayout(LayoutKind.Sequential)]
-            public struct MOUSEINPUT {
-                public int dx;
-                public int dy;
-                public uint mouseData;
-                public uint dwFlags;
-                public uint time;
-                public IntPtr dwExtraInfo;
-            }
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct INPUT {
-                public uint type;
-                public MOUSEINPUT mi;
-            }
-
-            [DllImport("user32.dll", SetLastError = true)]
-            public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
-
-            public const int INPUT_MOUSE = 0;
-            public const int MOUSEEVENTF_MOVE = 0x0001;
-        }
-"@
-
-        $endTime = if ($Duration -gt 0) { $StartTime.AddSeconds($Duration) } else { [DateTime]::MaxValue }
-
-        while ((Get-Date) -lt $endTime) {
-            # Randomly select a method from the provided methods
-            $method = $Methods | Get-Random
-
-            switch ($method) {
-                'MouseSoftware' {
-                    # Move mouse using software method
-                    $currentPos = [System.Windows.Forms.Cursor]::Position
-                    $xOffset = Get-Random -Minimum -10 -Maximum 11
-                    $yOffset = Get-Random -Minimum -10 -Maximum 11
-                    $newPos = [System.Drawing.Point]::new($currentPos.X + $xOffset, $currentPos.Y + $yOffset)
-                    [System.Windows.Forms.Cursor]::Position = $newPos
-
-                    # Move back to original position after a short delay to minimize disruption
-                    Start-Sleep -Milliseconds 100
-                    [System.Windows.Forms.Cursor]::Position = $currentPos
-                }
-                'MouseHardware' {
-                    # Use hardware-level mouse movement
-                    $mouseInputStructure = New-Object MouseSimulator+INPUT
-                    $mouseInputStructure.type = [MouseSimulator]::INPUT_MOUSE
-                    $mouseInputStructure.mi.dx = Get-Random -Minimum -5 -Maximum 6
-                    $mouseInputStructure.mi.dy = Get-Random -Minimum -5 -Maximum 6
-                    $mouseInputStructure.mi.dwFlags = [MouseSimulator]::MOUSEEVENTF_MOVE
-                    $mouseInputStructure.mi.time = 0
-                    $mouseInputStructure.mi.dwExtraInfo = [IntPtr]::Zero
-
-                    $inputArray = @($mouseInputStructure)
-                    [MouseSimulator]::SendInput(1, $inputArray, [System.Runtime.InteropServices.Marshal]::SizeOf([type][MouseSimulator+INPUT])) | Out-Null
-                }
-                'Keyboard' {
-                    # Press a non-disruptive key (F15 is rarely used)
-                    [System.Windows.Forms.SendKeys]::SendWait("{F15}")
-                }
-                'SystemAPI' {
-                    # Directly tell Windows to stay awake
-                    [DisplayState]::SetThreadExecutionState(
-                        [DisplayState]::ES_CONTINUOUS -bor
-                        [DisplayState]::ES_SYSTEM_REQUIRED -bor
-                        [DisplayState]::ES_DISPLAY_REQUIRED)
-                }
-            }
-
-            # Wait for the specified interval
-            Start-Sleep -Milliseconds $Interval
-        }
-
-        # Reset execution state if we used the API
-        if ($Methods -contains 'SystemAPI') {
-            [DisplayState]::SetThreadExecutionState([DisplayState]::ES_CONTINUOUS)
-        }
-    } -ArgumentList $Interval, $Methods, $Duration, $startTime
-
-    if ($Duration -gt 0) {
-        Write-Host "PSMouseJiggler KeepAwake will run for $Duration seconds" -ForegroundColor Yellow
-    }
-    else {
-        Write-Host "PSMouseJiggler KeepAwake is running indefinitely. Use Stop-PSMouseJiggler to stop." -ForegroundColor Yellow
-    }
-
-    # Clear console if incognito mode is enabled
-    if ($Incognito) {
-        Clear-Host
-    }
 }
 
 #endregion
@@ -2146,6 +2126,5 @@ Export-ModuleMember -Function @(
     'Prevent-SystemIdle',
     'Send-KeyboardInput',
     'Send-MouseInput',
-    'Get-PSMJRecommendedMethods',
-    'Start-KeepAwake'
+    'Get-PSMJRecommendedMethods'
 )

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -1345,13 +1345,23 @@ function Save-PSMJProfile {
     }
 
     $interval = $Profile.PSObject.Properties['Interval']
-    if ($null -ne $interval -and $interval.Value -lt 1) {
-        throw "Profile Interval must be greater than zero."
+    if ($null -ne $interval) {
+        if ($interval.Value -isnot [int] -and $interval.Value -isnot [long] -and $interval.Value -isnot [double]) {
+            throw "Profile Interval must be a number."
+        }
+        if ([double]$interval.Value -lt 1) {
+            throw "Profile Interval must be greater than zero."
+        }
     }
 
     $duration = $Profile.PSObject.Properties['Duration']
-    if ($null -ne $duration -and $duration.Value -lt 0) {
-        throw "Profile Duration cannot be negative."
+    if ($null -ne $duration) {
+        if ($duration.Value -isnot [int] -and $duration.Value -isnot [long] -and $duration.Value -isnot [double]) {
+            throw "Profile Duration must be a number."
+        }
+        if ([double]$duration.Value -lt 0) {
+            throw "Profile Duration cannot be negative."
+        }
     }
 
     $config = Get-Configuration -ConfigFilePath $ConfigFilePath

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -11,6 +11,21 @@ Add-Type -AssemblyName System.Drawing
 $script:JigglingJob = $null
 $script:JigglingActive = $false
 
+function Sync-PSMJState {
+    if (-not $script:JigglingActive -or $null -eq $script:JigglingJob) {
+        return
+    }
+
+    $jobState = [string]$script:JigglingJob.State
+    if ($jobState -in @('Completed', 'Failed', 'Stopped')) {
+        if ($script:JigglingJob -is [System.Management.Automation.Job]) {
+            Remove-Job -Job $script:JigglingJob -Force -ErrorAction SilentlyContinue
+        }
+        $script:JigglingJob = $null
+        $script:JigglingActive = $false
+    }
+}
+
 #region Core Mouse Jiggling Functions
 
 <#
@@ -44,6 +59,7 @@ function Start-PSMouseJiggler {
     [CmdletBinding()]
     param (
         [Parameter()]
+        [ValidateRange(1, 2147483647)]
         [int]$Interval = 1000,
 
         [Parameter()]
@@ -51,14 +67,21 @@ function Start-PSMouseJiggler {
         [string]$MovementPattern = 'Random',
 
         [Parameter()]
+        [ValidateRange(0, 2147483647)]
         [int]$Duration = 0,
 
         [Parameter()]
         [switch]$Incognito
     )
 
+    Sync-PSMJState
     if ($script:JigglingActive) {
-        Write-Warning "PSMouseJiggler is already running. Use Stop-PSMouseJiggler to stop it first."
+        if ($Incognito) {
+            Clear-Host
+        }
+        else {
+            Write-Warning "PSMouseJiggler is already running. Use Stop-PSMouseJiggler to stop it first."
+        }
         return
     }
 
@@ -140,6 +163,7 @@ function Stop-PSMouseJiggler {
     [CmdletBinding()]
     param()
 
+    Sync-PSMJState
     if (-not $script:JigglingActive) {
         Write-Warning "PSMouseJiggler is not currently running."
         return
@@ -919,6 +943,39 @@ INCOGNITO MODE:
 
 #region Configuration Functions
 
+function Assert-Configuration {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [PSCustomObject]$Configuration
+    )
+
+    $movementPattern = $Configuration.PSObject.Properties['MovementPattern']
+    if ($null -ne $movementPattern -and $movementPattern.Value -notin @('Random', 'Horizontal', 'Vertical', 'Circular')) {
+        throw "MovementPattern must be Random, Horizontal, Vertical, or Circular."
+    }
+
+    foreach ($propertyName in @('MovementSpeed', 'JiggleInterval')) {
+        $property = $Configuration.PSObject.Properties[$propertyName]
+        if ($null -ne $property -and ($property.Value -isnot [int] -and $property.Value -isnot [long] -and $property.Value -isnot [double])) {
+            throw "$propertyName must be a number."
+        }
+        if ($null -ne $property -and $property.Value -lt 1) {
+            throw "$propertyName must be greater than zero."
+        }
+    }
+
+    $duration = $Configuration.PSObject.Properties['Duration']
+    if ($null -ne $duration -and ($duration.Value -isnot [int] -and $duration.Value -isnot [long] -and $duration.Value -isnot [double])) {
+        throw "Duration must be a number."
+    }
+    if ($null -ne $duration -and $duration.Value -lt 0) {
+        throw "Duration cannot be negative."
+    }
+
+    return $Configuration
+}
+
 <#
 .SYNOPSIS
     Gets configuration settings from the config file.
@@ -948,6 +1005,7 @@ function Get-Configuration {
     if (Test-Path $ConfigFilePath) {
         try {
             $config = Get-Content -Path $ConfigFilePath -Raw | ConvertFrom-Json
+            Assert-Configuration -Configuration $config | Out-Null
             Write-Verbose "Configuration loaded from $ConfigFilePath"
             return $config
         }
@@ -995,6 +1053,7 @@ function Save-Configuration {
     }
 
     try {
+        Assert-Configuration -Configuration $Configuration | Out-Null
         $configDir = Split-Path -Parent $ConfigFilePath
         if (-not (Test-Path $configDir)) {
             New-Item -ItemType Directory -Path $configDir -Force | Out-Null
@@ -1045,6 +1104,202 @@ function Update-Configuration {
     Save-Configuration -Configuration $config -ConfigFilePath $ConfigFilePath
 }
 
+function Get-PSMJProfile {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$ConfigFilePath
+    )
+
+    $config = Get-Configuration -ConfigFilePath $ConfigFilePath
+    $profilesProperty = $config.PSObject.Properties['Profiles']
+    if ($null -eq $profilesProperty -or $null -eq $profilesProperty.Value) {
+        return @()
+    }
+
+    if ($Name) {
+        $profileProperty = $profilesProperty.Value.PSObject.Properties[$Name]
+        if ($null -eq $profileProperty) {
+            Write-Error "Profile '$Name' was not found."
+            return
+        }
+
+        $profile = [PSCustomObject]@{ Name = $Name }
+        foreach ($property in $profileProperty.Value.PSObject.Properties) {
+            $profile | Add-Member -MemberType NoteProperty -Name $property.Name -Value $property.Value
+        }
+        return $profile
+    }
+
+    foreach ($profileProperty in $profilesProperty.Value.PSObject.Properties) {
+        $profile = [PSCustomObject]@{ Name = $profileProperty.Name }
+        foreach ($property in $profileProperty.Value.PSObject.Properties) {
+            $profile | Add-Member -MemberType NoteProperty -Name $property.Name -Value $property.Value
+        }
+        $profile
+    }
+}
+
+function Save-PSMJProfile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject]$Profile,
+
+        [Parameter()]
+        [string]$ConfigFilePath
+    )
+
+    $mode = $Profile.PSObject.Properties['Mode']
+    if ($null -eq $mode -or $mode.Value -notin @('MouseJiggler', 'KeepAwake')) {
+        throw "Profile Mode must be MouseJiggler or KeepAwake."
+    }
+
+    $interval = $Profile.PSObject.Properties['Interval']
+    if ($null -ne $interval -and $interval.Value -lt 1) {
+        throw "Profile Interval must be greater than zero."
+    }
+
+    $duration = $Profile.PSObject.Properties['Duration']
+    if ($null -ne $duration -and $duration.Value -lt 0) {
+        throw "Profile Duration cannot be negative."
+    }
+
+    $config = Get-Configuration -ConfigFilePath $ConfigFilePath
+    $profilesProperty = $config.PSObject.Properties['Profiles']
+    if ($null -eq $profilesProperty -or $null -eq $profilesProperty.Value) {
+        $config | Add-Member -MemberType NoteProperty -Name Profiles -Value ([PSCustomObject]@{}) -Force
+    }
+
+    $profileCopy = [PSCustomObject]@{}
+    foreach ($property in $Profile.PSObject.Properties) {
+        if ($property.Name -ne 'Name') {
+            $profileCopy | Add-Member -MemberType NoteProperty -Name $property.Name -Value $property.Value
+        }
+    }
+
+    $config.Profiles | Add-Member -MemberType NoteProperty -Name $Name -Value $profileCopy -Force
+    Save-Configuration -Configuration $config -ConfigFilePath $ConfigFilePath
+    Get-PSMJProfile -Name $Name -ConfigFilePath $ConfigFilePath
+}
+
+function Remove-PSMJProfile {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$ConfigFilePath
+    )
+
+    $config = Get-Configuration -ConfigFilePath $ConfigFilePath
+    $profilesProperty = $config.PSObject.Properties['Profiles']
+    $profileProperty = if ($null -ne $profilesProperty) { $profilesProperty.Value.PSObject.Properties[$Name] }
+    if ($null -eq $profileProperty) {
+        Write-Error "Profile '$Name' was not found."
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($Name, 'Remove saved profile')) {
+        $profilesProperty.Value.PSObject.Properties.Remove($Name)
+        Save-Configuration -Configuration $config -ConfigFilePath $ConfigFilePath
+    }
+}
+
+function Start-PSMJProfile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$ConfigFilePath
+    )
+
+    $profile = Get-PSMJProfile -Name $Name -ConfigFilePath $ConfigFilePath -ErrorAction Stop
+    $incognito = [bool]$profile.Incognito
+
+    switch ($profile.Mode) {
+        'MouseJiggler' {
+            $parameters = @{
+                Interval        = if ($null -ne $profile.Interval) { [int]$profile.Interval } else { 1000 }
+                MovementPattern = if ($profile.MovementPattern) { [string]$profile.MovementPattern } else { 'Random' }
+                Duration        = if ($null -ne $profile.Duration) { [int]$profile.Duration } else { 0 }
+                Incognito       = $incognito
+            }
+            Start-PSMouseJiggler @parameters
+        }
+        'KeepAwake' {
+            $methods = if ($null -ne $profile.Methods) { @($profile.Methods) } else { @('All') }
+            $parameters = @{
+                Methods   = $methods
+                Strategy  = if ($profile.Strategy) { [string]$profile.Strategy } else { 'Manual' }
+                Interval  = if ($null -ne $profile.Interval) { [int]$profile.Interval } else { 30000 }
+                Duration  = if ($null -ne $profile.Duration) { [int]$profile.Duration } else { 0 }
+                Incognito = $incognito
+            }
+            Start-KeepAwake @parameters
+        }
+        default {
+            throw "Profile '$Name' has unsupported mode '$($profile.Mode)'."
+        }
+    }
+}
+
+function Get-PSMJDiagnostics {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]$ConfigFilePath
+    )
+
+    Sync-PSMJState
+    $configurationValid = $true
+    $configuration = $null
+    try {
+        $configuration = Get-Configuration -ConfigFilePath $ConfigFilePath -WarningAction Stop
+    }
+    catch {
+        $configurationValid = $false
+    }
+
+    $jobState = 'NotStarted'
+    if ($null -ne $script:JigglingJob) {
+        $jobState = [string]$script:JigglingJob.State
+    }
+
+    $profileCount = 0
+    if ($null -ne $configuration) {
+        $profilesProperty = $configuration.PSObject.Properties['Profiles']
+        if ($null -ne $profilesProperty -and $null -ne $profilesProperty.Value) {
+            $profileCount = @($profilesProperty.Value.PSObject.Properties).Count
+        }
+    }
+
+    $module = Get-Module -Name PSMouseJiggler | Select-Object -First 1
+    [PSCustomObject]@{
+        ModuleName         = 'PSMouseJiggler'
+        ModuleVersion      = if ($null -ne $module) { [string]$module.Version } else { $null }
+        PowerShellVersion  = [string]$PSVersionTable.PSVersion
+        OperatingSystem    = [string]$PSVersionTable.OS
+        IsRunning          = [bool]$script:JigglingActive
+        JobState           = $jobState
+        ConfigurationValid = $configurationValid
+        ProfileCount       = $profileCount
+        ConfigFilePath     = if ($ConfigFilePath) { $ConfigFilePath } else { $null }
+    }
+}
+
 <#
 .SYNOPSIS
     Resets configuration to default values.
@@ -1080,6 +1335,7 @@ function Get-DefaultConfiguration {
         ScheduledTimes       = @()
         AutoJiggle           = $false
         Duration             = 0
+        Profiles             = [PSCustomObject]@{}
         GuiSettings          = @{
             WindowPosition   = @{
                 X = 0
@@ -1183,6 +1439,7 @@ function Start-MovementPattern {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
+        [ValidateRange(0, 2147483647)]
         [int]$DurationInSeconds
     )
 
@@ -1250,6 +1507,72 @@ function Get-PSMJScheduledTasks {
     }
 }
 
+function Get-PSMJScheduledTaskStatus {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]$TaskName = 'PSMouseJiggler*'
+    )
+
+    try {
+        $tasks = @(Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop)
+        foreach ($task in $tasks) {
+            $taskInfo = Get-ScheduledTaskInfo -TaskName $task.TaskName -TaskPath $task.TaskPath -ErrorAction Stop
+            [PSCustomObject]@{
+                TaskName       = $task.TaskName
+                TaskPath       = $task.TaskPath
+                State          = [string]$task.State
+                Enabled        = [bool]$task.Settings.Enabled
+                NextRunTime    = $taskInfo.NextRunTime
+                LastRunTime    = $taskInfo.LastRunTime
+                LastTaskResult = $taskInfo.LastTaskResult
+            }
+        }
+    }
+    catch {
+        Write-Warning "Error getting scheduled task status: $($_.Exception.Message)"
+        return @()
+    }
+}
+
+function New-PSMJScheduledProfileTask {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TaskName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ProfileName,
+
+        [Parameter(Mandatory)]
+        [DateTime]$StartTime,
+
+        [Parameter()]
+        [ValidateRange(0, 2147483647)]
+        [int]$RepeatIntervalMinutes = 0,
+
+        [Parameter()]
+        [string]$ConfigFilePath
+    )
+
+    Get-PSMJProfile -Name $ProfileName -ConfigFilePath $ConfigFilePath -ErrorAction Stop | Out-Null
+
+    $escapedProfileName = $ProfileName.Replace("'", "''")
+    $action = "Import-Module PSMouseJiggler -ErrorAction Stop; Start-PSMJProfile -Name '$escapedProfileName'"
+    if ($ConfigFilePath) {
+        $escapedConfigPath = $ConfigFilePath.Replace("'", "''")
+        $action += " -ConfigFilePath '$escapedConfigPath'"
+    }
+
+    New-PSMJScheduledTask `
+        -TaskName $TaskName `
+        -Action $action `
+        -StartTime $StartTime `
+        -RepeatIntervalMinutes $RepeatIntervalMinutes
+}
+
 <#
 .SYNOPSIS
     Creates a new scheduled task for PSMouseJiggler.
@@ -1286,6 +1609,7 @@ function New-PSMJScheduledTask {
         [DateTime]$StartTime,
 
         [Parameter()]
+        [ValidateRange(0, 2147483647)]
         [int]$RepeatIntervalMinutes = 0
     )
 
@@ -1559,6 +1883,29 @@ function Send-MouseInput {
     Write-Verbose "Sent hardware-level mouse movement: X=$XOffset, Y=$YOffset"
 }
 
+function Get-PSMJRecommendedMethods {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateSet('Adaptive', 'LowImpact', 'Compatibility')]
+        [string]$Strategy = 'Adaptive'
+    )
+
+    if ($Strategy -eq 'LowImpact') {
+        return @('SystemAPI')
+    }
+
+    if ($Strategy -eq 'Compatibility') {
+        return @('MouseSoftware')
+    }
+
+    if ($env:OS -eq 'Windows_NT') {
+        return @('SystemAPI', 'MouseHardware')
+    }
+
+    return @('MouseSoftware')
+}
+
 <#
 .SYNOPSIS
     Keeps the system awake using multiple methods.
@@ -1591,17 +1938,29 @@ function Start-KeepAwake {
         [string[]]$Methods = @('All'),
 
         [Parameter()]
+        [ValidateSet('Manual', 'Adaptive')]
+        [string]$Strategy = 'Manual',
+
+        [Parameter()]
+        [ValidateRange(1, 2147483647)]
         [int]$Interval = 30000,
 
         [Parameter()]
+        [ValidateRange(0, 2147483647)]
         [int]$Duration = 0,
 
         [Parameter()]
         [switch]$Incognito
     )
 
+    Sync-PSMJState
     if ($script:JigglingActive) {
-        Write-Warning "PSMouseJiggler is already running. Use Stop-PSMouseJiggler to stop it first."
+        if ($Incognito) {
+            Clear-Host
+        }
+        else {
+            Write-Warning "PSMouseJiggler is already running. Use Stop-PSMouseJiggler to stop it first."
+        }
         return
     }
 
@@ -1611,7 +1970,10 @@ function Start-KeepAwake {
     $startTime = Get-Date
 
     # If 'All' is specified, use all methods
-    if ($Methods -contains 'All') {
+    if ($Strategy -eq 'Adaptive') {
+        $Methods = Get-PSMJRecommendedMethods -Strategy Adaptive
+    }
+    elseif ($Methods -contains 'All') {
         $Methods = @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
     }
 
@@ -1764,11 +2126,18 @@ Export-ModuleMember -Function @(
     'Save-Configuration',
     'Update-Configuration',
     'Reset-Configuration',
+    'Get-PSMJProfile',
+    'Save-PSMJProfile',
+    'Remove-PSMJProfile',
+    'Start-PSMJProfile',
+    'Get-PSMJDiagnostics',
     'Get-RandomMovementPattern',
     'Move-Mouse',
     'Start-MovementPattern',
     'Stop-MovementPattern',
     'Get-PSMJScheduledTasks',        # Updated name
+    'Get-PSMJScheduledTaskStatus',
+    'New-PSMJScheduledProfileTask',
     'New-PSMJScheduledTask',         # Updated name
     'Remove-PSMJScheduledTask',      # Updated name
     'Start-PSMJScheduledTask',       # Updated name
@@ -1777,5 +2146,6 @@ Export-ModuleMember -Function @(
     'Prevent-SystemIdle',
     'Send-KeyboardInput',
     'Send-MouseInput',
+    'Get-PSMJRecommendedMethods',
     'Start-KeepAwake'
 )

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -499,7 +499,7 @@ function Show-PSMouseJigglerGUI {
     $settingsGroupBox = New-Object System.Windows.Forms.GroupBox
     $settingsGroupBox.Text = "Basic Settings"
     $settingsGroupBox.Location = New-Object System.Drawing.Point(20, 100)
-    $settingsGroupBox.Size = New-Object System.Drawing.Size(500, 200)
+    $settingsGroupBox.Size = New-Object System.Drawing.Size(500, 230)
     $basicTab.Controls.Add($settingsGroupBox)
 
     # Movement Pattern
@@ -608,10 +608,45 @@ function Show-PSMouseJigglerGUI {
             }
         })
 
+    # Strategy (overrides Mouse Input Method with a recommended method combination when not Manual)
+    $strategyLabel = New-Object System.Windows.Forms.Label
+    $strategyLabel.Text = "Strategy:"
+    $strategyLabel.Location = New-Object System.Drawing.Point(15, 165)
+    $strategyLabel.Size = New-Object System.Drawing.Size(130, 20)
+    $settingsGroupBox.Controls.Add($strategyLabel)
+
+    $strategyComboBox = New-Object System.Windows.Forms.ComboBox
+    $strategyComboBox.Location = New-Object System.Drawing.Point(150, 163)
+    $strategyComboBox.Size = New-Object System.Drawing.Size(150, 20)
+    $strategyComboBox.DropDownStyle = "DropDownList"
+    $strategyComboBox.Items.AddRange(@("Manual", "Adaptive", "LowImpact", "Compatibility", "AppKeepAlive"))
+    $strategyComboBox.SelectedIndex = 0
+    $settingsGroupBox.Controls.Add($strategyComboBox)
+
+    $strategyDescLabel = New-Object System.Windows.Forms.Label
+    $strategyDescLabel.Text = "Manual: use Mouse Input Method below"
+    $strategyDescLabel.Location = New-Object System.Drawing.Point(310, 165)
+    $strategyDescLabel.Size = New-Object System.Drawing.Size(180, 20)
+    $strategyDescLabel.Font = New-Object System.Drawing.Font("Segoe UI", 7)
+    $strategyDescLabel.ForeColor = [System.Drawing.Color]::Gray
+    $settingsGroupBox.Controls.Add($strategyDescLabel)
+
+    $strategyComboBox.Add_SelectedIndexChanged({
+            switch ($strategyComboBox.SelectedItem.ToString()) {
+                'Manual' { $strategyDescLabel.Text = "Manual: use Mouse Input Method below" }
+                'Adaptive' { $strategyDescLabel.Text = "SystemAPI + Hardware mouse (Windows)" }
+                'LowImpact' { $strategyDescLabel.Text = "SystemAPI only, no mouse movement" }
+                'Compatibility' { $strategyDescLabel.Text = "Software mouse only, most compatible" }
+                'AppKeepAlive' { $strategyDescLabel.Text = "SystemAPI + Keyboard, keeps apps active" }
+            }
+            # A strategy other than Manual overrides Mouse Input Method, so grey it out
+            $mouseTypeComboBox.Enabled = ($strategyComboBox.SelectedItem.ToString() -eq 'Manual')
+        })
+
     # Incognito mode checkbox
     $incognitoCheckbox = New-Object System.Windows.Forms.CheckBox
     $incognitoCheckbox.Text = "Incognito Mode (minimize window & clear console)"
-    $incognitoCheckbox.Location = New-Object System.Drawing.Point(15, 165)
+    $incognitoCheckbox.Location = New-Object System.Drawing.Point(15, 195)
     $incognitoCheckbox.Size = New-Object System.Drawing.Size(350, 20)
     $settingsGroupBox.Controls.Add($incognitoCheckbox)
     #endregion
@@ -804,6 +839,9 @@ function Show-PSMouseJigglerGUI {
                 $startButton.Enabled = $false
                 $stopButton.Enabled = $true
                 $tabControl.SelectedIndex = 0
+                $form.WindowState = [System.Windows.Forms.FormWindowState]::Minimized
+                $form.ShowInTaskbar = $false
+                $notifyIcon.Visible = $true
             }
             catch {
                 [System.Windows.Forms.MessageBox]::Show("Error: $($_.Exception.Message)", "Error", "OK", "Error")
@@ -834,6 +872,9 @@ function Show-PSMouseJigglerGUI {
                 $startButton.Enabled = $false
                 $stopButton.Enabled = $true
                 $tabControl.SelectedIndex = 0
+                $form.WindowState = [System.Windows.Forms.FormWindowState]::Minimized
+                $form.ShowInTaskbar = $false
+                $notifyIcon.Visible = $true
             }
             catch {
                 [System.Windows.Forms.MessageBox]::Show("Error: $($_.Exception.Message)", "Error", "OK", "Error")
@@ -864,6 +905,9 @@ function Show-PSMouseJigglerGUI {
                 $startButton.Enabled = $false
                 $stopButton.Enabled = $true
                 $tabControl.SelectedIndex = 0
+                $form.WindowState = [System.Windows.Forms.FormWindowState]::Minimized
+                $form.ShowInTaskbar = $false
+                $notifyIcon.Visible = $true
             }
             catch {
                 [System.Windows.Forms.MessageBox]::Show("Error: $($_.Exception.Message)", "Error", "OK", "Error")
@@ -894,6 +938,9 @@ function Show-PSMouseJigglerGUI {
                 $startButton.Enabled = $false
                 $stopButton.Enabled = $true
                 $tabControl.SelectedIndex = 0
+                $form.WindowState = [System.Windows.Forms.FormWindowState]::Minimized
+                $form.ShowInTaskbar = $false
+                $notifyIcon.Visible = $true
             }
             catch {
                 [System.Windows.Forms.MessageBox]::Show("Error: $($_.Exception.Message)", "Error", "OK", "Error")
@@ -918,12 +965,47 @@ function Show-PSMouseJigglerGUI {
                 $startButton.Enabled = $false
                 $stopButton.Enabled = $true
                 $tabControl.SelectedIndex = 0
+                $form.WindowState = [System.Windows.Forms.FormWindowState]::Minimized
+                $form.ShowInTaskbar = $false
+                $notifyIcon.Visible = $true
             }
             catch {
                 [System.Windows.Forms.MessageBox]::Show("Error: $($_.Exception.Message)", "Error", "OK", "Error")
             }
         })
     #endregion
+
+    # System tray icon lets the user restore or stop jiggling once the window is minimized/hidden by Incognito mode
+    $notifyIcon = New-Object System.Windows.Forms.NotifyIcon
+    $notifyIcon.Icon = [System.Drawing.SystemIcons]::Application
+    $notifyIcon.Text = "PSMouseJiggler"
+    $notifyIcon.Visible = $false
+
+    $trayMenu = New-Object System.Windows.Forms.ContextMenuStrip
+    $trayShowItem = $trayMenu.Items.Add("Show Window")
+    $trayStopItem = $trayMenu.Items.Add("Stop Jiggling")
+    $notifyIcon.ContextMenuStrip = $trayMenu
+
+    $restoreFormAction = {
+        $form.WindowState = [System.Windows.Forms.FormWindowState]::Normal
+        $form.ShowInTaskbar = $true
+        $form.Activate()
+    }
+
+    $stopJigglingAction = {
+        Stop-PSMouseJiggler
+        $statusLabel.Text = "Status: Stopped"
+        $statusLabel.ForeColor = [System.Drawing.Color]::DarkRed
+        $statusDetailsLabel.Text = "Ready to start mouse jiggling"
+        $startButton.Enabled = $true
+        $stopButton.Enabled = $false
+        $notifyIcon.Visible = $false
+        & $restoreFormAction
+    }
+
+    $trayShowItem.Add_Click($restoreFormAction)
+    $trayStopItem.Add_Click($stopJigglingAction)
+    $notifyIcon.Add_DoubleClick($restoreFormAction)
 
     #region Control Buttons
     # Start button
@@ -943,9 +1025,15 @@ function Show-PSMouseJigglerGUI {
                     $duration = [int]$durationTextBox.Text
                     $pattern = $patternComboBox.SelectedItem.ToString()
                     $incognito = $incognitoCheckbox.Checked
+                    $strategy = $strategyComboBox.SelectedItem.ToString()
 
+                    if ($strategy -ne 'Manual') {
+                        # Strategy overrides Mouse Input Method with a recommended method combination
+                        Start-PSMouseJiggler -Strategy $strategy -Interval $interval -Duration $duration -Incognito:$incognito
+                        $statusDetailsLabel.Text = "Mode: Basic | Strategy: $strategy"
+                    }
                     # Determine mouse methods based on selection
-                    if ($mouseTypeComboBox.SelectedIndex -eq 1) {
+                    elseif ($mouseTypeComboBox.SelectedIndex -eq 1) {
                         # Hardware only
                         Start-PSMouseJiggler -Methods @('MouseHardware') -Interval $interval -Duration $duration -Incognito:$incognito
                         $statusDetailsLabel.Text = "Mode: Basic | Pattern: $pattern | Method: Hardware Mouse"
@@ -994,6 +1082,7 @@ function Show-PSMouseJigglerGUI {
                 if ($incognito -or $advIncognitoCheckbox.Checked) {
                     $form.WindowState = [System.Windows.Forms.FormWindowState]::Minimized
                     $form.ShowInTaskbar = $false
+                    $notifyIcon.Visible = $true
                 }
             }
             catch {
@@ -1012,21 +1101,7 @@ function Show-PSMouseJigglerGUI {
     $stopButton.ForeColor = [System.Drawing.Color]::White
     $stopButton.Font = New-Object System.Drawing.Font("Segoe UI", 10, [System.Drawing.FontStyle]::Bold)
     $stopButton.FlatStyle = "Flat"
-    $stopButton.Add_Click({
-            Stop-PSMouseJiggler
-            $statusLabel.Text = "Status: Stopped"
-            $statusLabel.ForeColor = [System.Drawing.Color]::DarkRed
-            $statusDetailsLabel.Text = "Ready to start mouse jiggling"
-            $startButton.Enabled = $true
-            $stopButton.Enabled = $false
-
-            # Restore form if it was minimized
-            if ($form.WindowState -eq [System.Windows.Forms.FormWindowState]::Minimized) {
-                $form.WindowState = [System.Windows.Forms.FormWindowState]::Normal
-                $form.ShowInTaskbar = $true
-                $form.Activate()
-            }
-        })
+    $stopButton.Add_Click($stopJigglingAction)
     $form.Controls.Add($stopButton)
 
     # Help button
@@ -1050,6 +1125,11 @@ BASIC MODE:
   * Software: Standard method (most compatible)
   * Hardware: Low-level input (better for strict policies)
   * Both: Maximum reliability
+- Or pick a Strategy to override Mouse Input Method with a recommended combination:
+  * Adaptive: SystemAPI + Hardware mouse (Windows)
+  * LowImpact: SystemAPI only, no mouse movement
+  * Compatibility: Software mouse only, most compatible
+  * AppKeepAlive: SystemAPI + Keyboard, keeps apps active without moving the mouse
 
 ADVANCED MODE:
 - Select multiple methods for maximum effectiveness
@@ -1064,9 +1144,10 @@ QUICK LAUNCH:
 - All profiles use incognito mode
 
 INCOGNITO MODE:
-- Minimizes window when started
+- Minimizes window and hides it from the taskbar
 - Clears console output
 - Runs discreetly in background
+- Use the system tray icon (right-click for Show/Stop, or double-click to restore) to regain control
 "@
             [System.Windows.Forms.MessageBox]::Show($helpMessage, "PSMouseJiggler Help", "OK", "Information")
         })
@@ -1083,12 +1164,11 @@ INCOGNITO MODE:
                 $statusDetailsLabel.Text = "Ready to start mouse jiggling"
                 $startButton.Enabled = $true
                 $stopButton.Enabled = $false
+                $notifyIcon.Visible = $false
 
                 # Restore form if it was minimized
                 if ($form.WindowState -eq [System.Windows.Forms.FormWindowState]::Minimized) {
-                    $form.WindowState = [System.Windows.Forms.FormWindowState]::Normal
-                    $form.ShowInTaskbar = $true
-                    $form.Activate()
+                    & $restoreFormAction
                 }
             }
         })
@@ -1113,7 +1193,7 @@ INCOGNITO MODE:
             $form.Activate()
         })
 
-    $form.Add_FormClosed({ $timer.Stop() })
+    $form.Add_FormClosed({ $timer.Stop(); $notifyIcon.Visible = $false; $notifyIcon.Dispose() })
     [void]$form.ShowDialog()
 }
 

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -451,9 +451,9 @@ function Show-PSMouseJigglerGUI {
     [CmdletBinding()]
     param()
 
-    # Create the main form
+    # Create the main form (rememeber to update version number in the title if you change it!)
     $form = New-Object System.Windows.Forms.Form
-    $form.Text = "PSMouseJiggler v1.1.0"
+    $form.Text = "PSMouseJiggler v2.2.0"
     $form.Size = New-Object System.Drawing.Size(600, 550)
     $form.StartPosition = "CenterScreen"
     $form.FormBorderStyle = "FixedDialog"

--- a/src/PSMouseJiggler/PSMouseJiggler.psm1
+++ b/src/PSMouseJiggler/PSMouseJiggler.psm1
@@ -12,7 +12,12 @@ $script:JigglingJob = $null
 $script:JigglingActive = $false
 
 function Sync-PSMJState {
-    if (-not $script:JigglingActive -or $null -eq $script:JigglingJob) {
+    if (-not $script:JigglingActive) {
+        return
+    }
+
+    if ($null -eq $script:JigglingJob) {
+        $script:JigglingActive = $false
         return
     }
 

--- a/src/PSMouseJiggler/README.md
+++ b/src/PSMouseJiggler/README.md
@@ -31,7 +31,7 @@ Start-PSMouseJiggler
 Start-PSMouseJiggler -Incognito
 
 # Use advanced keep-awake methods
-Start-KeepAwake -Methods @('MouseHardware', 'SystemAPI')
+Start-PSMouseJiggler -Methods @('MouseHardware', 'SystemAPI')
 
 # Stop any running jiggler
 Stop-PSMouseJiggler
@@ -70,8 +70,7 @@ Show-PSMouseJigglerGUI
 
 ### Core Functions
 
-- `Start-PSMouseJiggler` - Start mouse jiggling with optional incognito mode
-- `Start-KeepAwake` - Advanced multi-method keep-awake functionality
+- `Start-PSMouseJiggler` - Start mouse jiggling with optional -Methods/-Strategy for advanced keep-awake
 - `Stop-PSMouseJiggler` - Stop any running jiggler or keep-awake process
 - `Show-PSMouseJigglerGUI` - Open the modern tabbed GUI interface
 
@@ -115,20 +114,23 @@ Start-PSMouseJiggler -Interval 2000 -MovementPattern 'Circular'
 Start-PSMouseJiggler -Duration 300 -Incognito
 
 # Use hardware mouse input for strict security policies
-Start-KeepAwake -Methods @('MouseHardware') -Interval 30000
+Start-PSMouseJiggler -Methods @('MouseHardware') -Interval 30000
 ```
 
 ### Advanced Keep-Awake Usage
 
 ```powershell
 # Use multiple methods for maximum reliability
-Start-KeepAwake -Methods @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
+Start-PSMouseJiggler -Methods @('MouseSoftware', 'MouseHardware', 'Keyboard', 'SystemAPI')
 
 # Keyboard only (no visible movement)
-Start-KeepAwake -Methods @('Keyboard') -Interval 30000 -Incognito
+Start-PSMouseJiggler -Methods @('Keyboard') -Interval 30000 -Incognito
 
 # System API only (minimal resource usage)
-Start-KeepAwake -Methods @('SystemAPI') -Interval 60000
+Start-PSMouseJiggler -Methods @('SystemAPI') -Interval 60000
+
+# AppKeepAlive strategy: SystemAPI + Keyboard, keeps some apps active without moving the mouse
+Start-PSMouseJiggler -Strategy AppKeepAlive -Interval 30000
 ```
 
 ### GUI Usage
@@ -204,6 +206,16 @@ The GUI provides three main tabs:
 - Descriptions and recommended scenarios included
 
 ## Version History
+
+### Version 2.0.0
+
+- **BREAKING**: Removed `Start-KeepAwake`. Use `Start-PSMouseJiggler -Methods`/`-Strategy` instead
+- Added `-Methods` and `-Strategy` parameters to `Start-PSMouseJiggler`, unifying basic mouse
+  jiggling and multi-method keep-awake into a single entry point
+- Added `AppKeepAlive` strategy (SystemAPI + Keyboard) to keep some Windows apps active without
+  visible mouse movement
+- Saved profiles no longer use a `Mode` field; they carry Interval/Duration/MovementPattern/
+  Methods/Strategy/Incognito and are started with `Start-PSMJProfile`
 
 ### Version 1.1.0 (October 2025)
 

--- a/src/PSMouseJiggler/config/default.json
+++ b/src/PSMouseJiggler/config/default.json
@@ -6,6 +6,7 @@
     "scheduledTimes": [],
     "autoJiggle": false,
     "duration": 0,
+    "profiles": {},
     "guiSettings": {
         "windowPosition": {
             "x": 0,

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -1,4 +1,0 @@
-{
-  "MovementSpeed": 10,
-  "MovementPattern": "Linear"
-}

--- a/tests/PSMouseJiggler.Tests.ps1
+++ b/tests/PSMouseJiggler.Tests.ps1
@@ -41,6 +41,8 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
                 'Start-MovementPattern',
                 'Stop-MovementPattern',
                 'Get-PSMJScheduledTasks',       # Updated name
+                'Get-PSMJScheduledTaskStatus',
+                'New-PSMJScheduledProfileTask',
                 'New-PSMJScheduledTask',        # Updated name
                 'Remove-PSMJScheduledTask',     # Updated name
                 'Start-PSMJScheduledTask',      # Updated name
@@ -48,7 +50,10 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
                 'Prevent-SystemIdle',
                 'Send-KeyboardInput',
                 'Send-MouseInput',
-                'Start-KeepAwake'
+                'Get-PSMJRecommendedMethods',
+                'Start-KeepAwake',
+                'Start-PSMJProfile',
+                'Get-PSMJDiagnostics'
             )
 
             foreach ($function in $requiredFunctions) {
@@ -71,6 +76,215 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
             Start-Sleep -Seconds 2
 
             # Step 4: Stop the keep-awake functionality
+            { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
+        It 'Should clear the host without warning when an incognito start is already running' {
+            InModuleScope PSMouseJiggler {
+                Mock Clear-Host
+
+                Start-PSMouseJiggler -Duration 10
+                $warning = $null
+                Start-KeepAwake -Incognito -WarningVariable warning
+
+                $warning | Should -BeNullOrEmpty
+                Should -Invoke Clear-Host -Exactly 1
+
+                Stop-PSMouseJiggler
+            }
+        }
+
+        It 'Should reject non-positive movement intervals' {
+            { Start-PSMouseJiggler -Interval 0 } | Should -Throw
+        }
+
+        It 'Should reject negative durations' {
+            { Start-KeepAwake -Duration -1 } | Should -Throw
+        }
+
+        It 'Should use defaults when a configuration contains invalid values' {
+            $configPath = Join-Path $TestDrive 'invalid-config.json'
+            '{"MovementPattern":"Unknown","JiggleInterval":0}' | Set-Content -Path $configPath
+
+            $config = Get-Configuration -ConfigFilePath $configPath -WarningAction SilentlyContinue
+
+            $config.MovementPattern | Should -Be 'Random'
+            $config.JiggleInterval | Should -Be 1000
+        }
+
+        It 'Should save, retrieve, list, and remove a profile' {
+            $configPath = Join-Path $TestDrive 'profiles.json'
+            $profile = [PSCustomObject]@{
+                Mode            = 'MouseJiggler'
+                Interval        = 1500
+                Duration        = 60
+                MovementPattern = 'Circular'
+                Incognito       = $true
+            }
+
+            $saved = Save-PSMJProfile -Name 'Presentation' -Profile $profile -ConfigFilePath $configPath
+            $saved.Name | Should -Be 'Presentation'
+            $saved.MovementPattern | Should -Be 'Circular'
+
+            $listed = @(Get-PSMJProfile -ConfigFilePath $configPath)
+            $listed.Count | Should -Be 1
+            $listed[0].Name | Should -Be 'Presentation'
+
+            Remove-PSMJProfile -Name 'Presentation' -ConfigFilePath $configPath -Confirm:$false
+            @(Get-PSMJProfile -ConfigFilePath $configPath).Count | Should -Be 0
+        }
+
+        It 'Should reject profiles with unsupported modes' {
+            $profile = [PSCustomObject]@{
+                Mode     = 'Unsupported'
+                Interval = 1000
+                Duration = 0
+            }
+
+            { Save-PSMJProfile -Name 'Invalid' -Profile $profile -ConfigFilePath (Join-Path $TestDrive 'invalid-profile.json') } | Should -Throw
+        }
+
+        It 'Should execute a saved mouse jiggler profile' {
+            $configPath = Join-Path $TestDrive 'mouse-profile.json'
+            $profile = [PSCustomObject]@{
+                Mode            = 'MouseJiggler'
+                Interval        = 1000
+                Duration        = 1
+                MovementPattern = 'Random'
+            }
+
+            Save-PSMJProfile -Name 'ShortMouse' -Profile $profile -ConfigFilePath $configPath | Out-Null
+            { Start-PSMJProfile -Name 'ShortMouse' -ConfigFilePath $configPath } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
+        It 'Should execute a saved keep-awake profile' {
+            $configPath = Join-Path $TestDrive 'keepawake-profile.json'
+            $profile = [PSCustomObject]@{
+                Mode     = 'KeepAwake'
+                Methods  = @('SystemAPI')
+                Interval = 1000
+                Duration = 1
+            }
+
+            Save-PSMJProfile -Name 'ShortKeepAwake' -Profile $profile -ConfigFilePath $configPath | Out-Null
+            { Start-PSMJProfile -Name 'ShortKeepAwake' -ConfigFilePath $configPath } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
+        It 'Should return diagnostics for the module and saved profiles' {
+            $configPath = Join-Path $TestDrive 'diagnostics.json'
+            $profile = [PSCustomObject]@{
+                Mode     = 'KeepAwake'
+                Interval = 30000
+                Duration = 0
+            }
+
+            Save-PSMJProfile -Name 'DiagnosticsProfile' -Profile $profile -ConfigFilePath $configPath | Out-Null
+            $diagnostics = Get-PSMJDiagnostics -ConfigFilePath $configPath
+
+            $diagnostics.ModuleName | Should -Be 'PSMouseJiggler'
+            $diagnostics.ConfigurationValid | Should -BeTrue
+            $diagnostics.IsRunning | Should -BeFalse
+            $diagnostics.JobState | Should -Be 'NotStarted'
+            $diagnostics.ProfileCount | Should -Be 1
+        }
+
+        It 'Should report invalid configuration in diagnostics' {
+            $configPath = Join-Path $TestDrive 'diagnostics-invalid.json'
+            '{"MovementPattern":"Unknown"}' | Set-Content -Path $configPath
+
+            $diagnostics = Get-PSMJDiagnostics -ConfigFilePath $configPath
+
+            $diagnostics.ConfigurationValid | Should -BeFalse
+            $diagnostics.ProfileCount | Should -Be 0
+        }
+
+        It 'Should normalize scheduled task status for UI consumers' {
+            InModuleScope PSMouseJiggler {
+                $task = [PSCustomObject]@{
+                    TaskName = 'PSMouseJiggler-Work'
+                    TaskPath = '\'
+                    State    = 'Ready'
+                    Settings = [PSCustomObject]@{ Enabled = $true }
+                }
+                $taskInfo = [PSCustomObject]@{
+                    NextRunTime    = [datetime]'2026-08-21T09:00:00'
+                    LastRunTime    = [datetime]'2026-08-20T17:00:00'
+                    LastTaskResult = 0
+                }
+
+                Mock Get-ScheduledTask { $task }
+                Mock Get-ScheduledTaskInfo { $taskInfo }
+
+                $status = @(Get-PSMJScheduledTaskStatus -TaskName 'PSMouseJiggler-*')
+
+                $status.Count | Should -Be 1
+                $status[0].TaskName | Should -Be 'PSMouseJiggler-Work'
+                $status[0].State | Should -Be 'Ready'
+                $status[0].Enabled | Should -BeTrue
+                $status[0].LastTaskResult | Should -Be 0
+            }
+        }
+
+        It 'Should create a scheduled task action for a saved profile' {
+            InModuleScope PSMouseJiggler {
+                $configPath = Join-Path $TestDrive 'scheduled-profile.json'
+                $profile = [PSCustomObject]@{
+                    Mode     = 'KeepAwake'
+                    Methods  = @('SystemAPI')
+                    Interval = 30000
+                    Duration = 0
+                }
+                Save-PSMJProfile -Name "Work Profile" -Profile $profile -ConfigFilePath $configPath | Out-Null
+                Mock New-PSMJScheduledTask
+
+                New-PSMJScheduledProfileTask `
+                    -TaskName 'PSMJ-Work' `
+                    -ProfileName "Work Profile" `
+                    -StartTime ([datetime]'2026-08-21T09:00:00') `
+                    -RepeatIntervalMinutes 30 `
+                    -ConfigFilePath $configPath
+
+                Should -Invoke New-PSMJScheduledTask -Exactly 1 -ParameterFilter {
+                    $TaskName -eq 'PSMJ-Work' -and
+                    $Action -match "Start-PSMJProfile -Name 'Work Profile'" -and
+                    $Action -match [regex]::Escape("-ConfigFilePath '$configPath'") -and
+                    $RepeatIntervalMinutes -eq 30
+                }
+            }
+        }
+
+        It 'Should recommend methods for each keep-awake strategy' {
+            @(Get-PSMJRecommendedMethods -Strategy LowImpact) | Should -Be @('SystemAPI')
+            @(Get-PSMJRecommendedMethods -Strategy Compatibility) | Should -Be @('MouseSoftware')
+
+            $adaptiveMethods = @(Get-PSMJRecommendedMethods -Strategy Adaptive)
+            $adaptiveMethods.Count | Should -BeGreaterThan 0
+            $adaptiveMethods | Should -Contain 'SystemAPI'
+        }
+
+        It 'Should execute an adaptive keep-awake session' {
+            { Start-KeepAwake -Strategy Adaptive -Duration 1 -Interval 1000 } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
+        It 'Should reconcile completed jobs before reporting or starting again' {
+            { Start-PSMouseJiggler -Duration 1 -Interval 1000 } | Should -Not -Throw
+
+            $deadline = (Get-Date).AddSeconds(10)
+            do {
+                Start-Sleep -Milliseconds 250
+                $diagnostics = Get-PSMJDiagnostics
+            } while ($diagnostics.IsRunning -and (Get-Date) -lt $deadline)
+
+            $diagnostics.IsRunning | Should -BeFalse
+            $diagnostics.JobState | Should -Be 'NotStarted'
+
+            { Start-PSMouseJiggler -Duration 1 -Interval 1000 } | Should -Not -Throw
             { Stop-PSMouseJiggler } | Should -Not -Throw
         }
     }

--- a/tests/PSMouseJiggler.Tests.ps1
+++ b/tests/PSMouseJiggler.Tests.ps1
@@ -51,7 +51,6 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
                 'Send-KeyboardInput',
                 'Send-MouseInput',
                 'Get-PSMJRecommendedMethods',
-                'Start-KeepAwake',
                 'Start-PSMJProfile',
                 'Get-PSMJDiagnostics'
             )
@@ -72,7 +71,7 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
             { Stop-PSMouseJiggler } | Should -Not -Throw
 
             # Step 3: Start the keep-awake functionality with a short duration
-            { Start-KeepAwake -Duration 1 } | Should -Not -Throw
+            { Start-PSMouseJiggler -Methods @('SystemAPI', 'Keyboard') -Duration 1 } | Should -Not -Throw
             Start-Sleep -Seconds 2
 
             # Step 4: Stop the keep-awake functionality
@@ -85,7 +84,7 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
 
                 Start-PSMouseJiggler -Duration 10
                 $warning = $null
-                Start-KeepAwake -Incognito -WarningVariable warning
+                Start-PSMouseJiggler -Methods @('SystemAPI', 'Keyboard') -Incognito -WarningVariable warning
 
                 $warning | Should -BeNullOrEmpty
                 Should -Invoke Clear-Host -Exactly 1
@@ -99,7 +98,7 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
         }
 
         It 'Should reject negative durations' {
-            { Start-KeepAwake -Duration -1 } | Should -Throw
+            { Start-PSMouseJiggler -Methods @('SystemAPI') -Duration -1 } | Should -Throw
         }
 
         It 'Should use defaults when a configuration contains invalid values' {
@@ -115,7 +114,6 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
         It 'Should save, retrieve, list, and remove a profile' {
             $configPath = Join-Path $TestDrive 'profiles.json'
             $profile = [PSCustomObject]@{
-                Mode            = 'MouseJiggler'
                 Interval        = 1500
                 Duration        = 60
                 MovementPattern = 'Circular'
@@ -134,9 +132,9 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
             @(Get-PSMJProfile -ConfigFilePath $configPath).Count | Should -Be 0
         }
 
-        It 'Should reject profiles with unsupported modes' {
+        It 'Should reject profiles with invalid method names' {
             $profile = [PSCustomObject]@{
-                Mode     = 'Unsupported'
+                Methods  = @('Unsupported')
                 Interval = 1000
                 Duration = 0
             }
@@ -147,7 +145,6 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
         It 'Should execute a saved mouse jiggler profile' {
             $configPath = Join-Path $TestDrive 'mouse-profile.json'
             $profile = [PSCustomObject]@{
-                Mode            = 'MouseJiggler'
                 Interval        = 1000
                 Duration        = 1
                 MovementPattern = 'Random'
@@ -162,7 +159,6 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
         It 'Should execute a saved keep-awake profile' {
             $configPath = Join-Path $TestDrive 'keepawake-profile.json'
             $profile = [PSCustomObject]@{
-                Mode     = 'KeepAwake'
                 Methods  = @('SystemAPI')
                 Interval = 1000
                 Duration = 1
@@ -174,10 +170,24 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
             { Stop-PSMouseJiggler } | Should -Not -Throw
         }
 
+        It 'Should execute a saved AppKeepAlive profile' {
+            $configPath = Join-Path $TestDrive 'appkeepalive-profile.json'
+            $profile = [PSCustomObject]@{
+                Strategy = 'AppKeepAlive'
+                Interval = 1000
+                Duration = 1
+            }
+
+            Save-PSMJProfile -Name 'ShortAppKeepAlive' -Profile $profile -ConfigFilePath $configPath | Out-Null
+            { Start-PSMJProfile -Name 'ShortAppKeepAlive' -ConfigFilePath $configPath } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
         It 'Should return diagnostics for the module and saved profiles' {
             $configPath = Join-Path $TestDrive 'diagnostics.json'
             $profile = [PSCustomObject]@{
-                Mode     = 'KeepAwake'
+                Methods  = @('SystemAPI')
                 Interval = 30000
                 Duration = 0
             }
@@ -233,7 +243,6 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
             InModuleScope PSMouseJiggler {
                 $configPath = Join-Path $TestDrive 'scheduled-profile.json'
                 $profile = [PSCustomObject]@{
-                    Mode     = 'KeepAwake'
                     Methods  = @('SystemAPI')
                     Interval = 30000
                     Duration = 0
@@ -260,6 +269,7 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
         It 'Should recommend methods for each keep-awake strategy' {
             @(Get-PSMJRecommendedMethods -Strategy LowImpact) | Should -Be @('SystemAPI')
             @(Get-PSMJRecommendedMethods -Strategy Compatibility) | Should -Be @('MouseSoftware')
+            @(Get-PSMJRecommendedMethods -Strategy AppKeepAlive) | Should -Be @('SystemAPI', 'Keyboard')
 
             $adaptiveMethods = @(Get-PSMJRecommendedMethods -Strategy Adaptive)
             $adaptiveMethods.Count | Should -BeGreaterThan 0
@@ -267,9 +277,23 @@ Describe 'PSMouseJiggler Basic Functionality Tests' {
         }
 
         It 'Should execute an adaptive keep-awake session' {
-            { Start-KeepAwake -Strategy Adaptive -Duration 1 -Interval 1000 } | Should -Not -Throw
+            { Start-PSMouseJiggler -Strategy Adaptive -Duration 1 -Interval 1000 } | Should -Not -Throw
             Start-Sleep -Seconds 2
             { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
+        It 'Should execute an AppKeepAlive session without moving the mouse' {
+            { Start-PSMouseJiggler -Strategy AppKeepAlive -Duration 1 -Interval 1000 } | Should -Not -Throw
+            Start-Sleep -Seconds 2
+            { Stop-PSMouseJiggler } | Should -Not -Throw
+        }
+
+        It 'Should still support all movement patterns via the default Methods' {
+            foreach ($pattern in @('Random', 'Horizontal', 'Vertical', 'Circular')) {
+                { Start-PSMouseJiggler -MovementPattern $pattern -Duration 1 -Interval 1000 } | Should -Not -Throw
+                Start-Sleep -Seconds 2
+                { Stop-PSMouseJiggler } | Should -Not -Throw
+            }
         }
 
         It 'Should reconcile completed jobs before reporting or starting again' {


### PR DESCRIPTION
## Summary

Breaking-change release (v2.0.0) that unifies mouse jiggling and multi-method keep-awake, adds a new strategy, and fixes a real bug found during manual testing.

### Changes

- **Unified API**: `Start-PSMouseJiggler` now supports `-Methods` and `-Strategy` params, covering everything `Start-KeepAwake` used to do. `Start-KeepAwake` is removed.
- **New `AppKeepAlive` strategy**: `SystemAPI` + `Keyboard` combo to keep some Windows apps active without visible mouse movement (`Get-PSMJRecommendedMethods -Strategy AppKeepAlive`).
- **Bug fix — mouse not moving**: `System.Windows.Forms.Cursor` is unreliable inside a `Start-Job` background process (no UI message pump), causing silent, intermittent failures. Replaced with raw `user32.dll` `GetCursorPos`/`SetCursorPos` P/Invoke calls.
- **Bug fix — module install layout**: `install.ps1` now installs into a versioned subfolder (`PSMouseJiggler\<version>\`) instead of a flat folder, preventing `Import-Module PSMouseJiggler` from silently resolving to a stale version when older Gallery-installed versions exist side-by-side.
- **Simplified profile schema**: saved profiles no longer use a `Mode` field (`MouseJiggler`/`KeepAwake`); they're started uniformly via `Start-PSMouseJiggler`.
- Updated Pester tests (21/21 passing), README/USAGE docs, and added `docs/TEST_PLAN.md` manual pre-release checklist.
- Bumped `ModuleVersion` to `2.0.0` with breaking-change release notes in the manifest.

### Testing

- `Invoke-Pester tests/PSMouseJiggler.Tests.ps1` — 21/21 passing
- `Invoke-ScriptAnalyzer -Path .\src -Recurse -Severity Error` — clean
- `Test-ModuleManifest` — valid, version 2.0.0
- Manual verification: cursor movement confirmed with 0 background-job errors; `Import-Module PSMouseJiggler` (by name) resolves to 2.0.0 after reinstall
- Manual checklist in `docs/TEST_PLAN.md` walked through prior to this PR

### Migration notes

- `Start-KeepAwake -Methods @(...)` → `Start-PSMouseJiggler -Methods @(...)`
- Saved profiles with a `Mode` field: the field is now ignored; re-save profiles without it if desired
